### PR TITLE
feat: Initial Ethereum CLI structure with 15 command groups

### DIFF
--- a/account_commands.py
+++ b/account_commands.py
@@ -1,0 +1,75 @@
+import click
+
+# Assume a way to get the current active wallet's address
+def get_active_wallet_address():
+    # Placeholder: In a real app, this would fetch from config or state
+    return "0xACTIV WALLETADDRESSDEFAULT00000000000"
+
+@click.group('account')
+def account_group():
+    """Show wallet balances, nonce, tokens, and resolve ENS names."""
+    pass
+
+@account_group.command('balance')
+@click.option('--address', 'target_address', type=str, help="Address to check balance for (defaults to active wallet).")
+@click.option('--token', 'token_contract_address', type=str, help="ERC-20 token contract address (optional).")
+@click.option('--block', 'block_identifier', type=str, help="Block number or tag (e.g., 'latest', 'pending', or a number) (optional).")
+def get_balance(target_address, token_contract_address, block_identifier):
+    """Show ETH or token balance for an address."""
+    address_to_check = target_address or get_active_wallet_address()
+    block_info = f" at block {block_identifier}" if block_identifier else ""
+
+    if token_contract_address:
+        click.echo(f"Fetching ERC-20 token balance for token {token_contract_address} at address {address_to_check}{block_info}...")
+        # Placeholder: Implement ERC-20 token balance fetching
+        # 1. Need ABI for ERC-20 (balanceOf function).
+        # 2. Call balanceOf(address_to_check) on the token_contract_address.
+        # 3. Format the result (considering token decimals).
+        click.echo(f"Token Balance (Token: {token_contract_address}): 123.45 TKN (Example)")
+    else:
+        click.echo(f"Fetching ETH balance for address: {address_to_check}{block_info}...")
+        # Placeholder: Implement ETH balance fetching (web3.eth.get_balance)
+        click.echo(f"ETH Balance: 1.2345 ETH (Example)")
+
+@account_group.command('nonce')
+@click.option('--address', 'target_address', type=str, help="Address to check nonce for (defaults to active wallet).")
+@click.option('--block', 'block_identifier', type=str, default='pending', help="Block number or tag (e.g., 'latest', 'pending') (defaults to 'pending').")
+def get_nonce(target_address, block_identifier):
+    """Show current nonce for an address."""
+    address_to_check = target_address or get_active_wallet_address()
+    click.echo(f"Fetching nonce for address: {address_to_check} at block: {block_identifier}...")
+    # Placeholder: Implement nonce fetching (web3.eth.get_transaction_count)
+    click.echo(f"Nonce: 42 (Example)")
+
+@account_group.command('tokens')
+@click.option('--address', 'target_address', type=str, help="Address to list tokens for (defaults to active wallet).")
+# Could add --min-balance to filter small balances
+def list_tokens(target_address):
+    """List ERC-20 tokens held by an address."""
+    address_to_check = target_address or get_active_wallet_address()
+    click.echo(f"Listing ERC-20 tokens for address: {address_to_check}...")
+    # Placeholder: Implement token listing. This is complex and might involve:
+    # 1. Querying a token list service (e.g., Uniswap's list, CoinGecko).
+    # 2. Or, scanning transaction history for 'Transfer' events to this address.
+    # 3. Or, using a service like Etherscan API or Covalent/Alchemy/Infura token APIs.
+    click.echo("  Token: DAI (0x6B175474E89094C44Da98b954EedeAC495271d0F), Balance: 100.0")
+    click.echo("  Token: USDC (0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48), Balance: 50.5")
+    click.echo("(Placeholder - requires external data source or indexing)")
+
+@account_group.command('ens')
+@click.argument('name_or_address', type=str)
+def resolve_ens(name_or_address):
+    """Resolve ENS name to address, or perform reverse lookup for an address."""
+    if name_or_address.startswith('0x'):
+        click.echo(f"Performing reverse ENS lookup for address: {name_or_address}...")
+        # Placeholder: Implement ENS reverse lookup (web3.ens.name(address))
+        click.echo(f"ENS Name: vitalik.eth (Example)")
+    elif '.eth' in name_or_address:
+        click.echo(f"Resolving ENS name: {name_or_address}...")
+        # Placeholder: Implement ENS name resolution (web3.ens.address(name))
+        click.echo(f"Address: 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045 (Example for vitalik.eth)")
+    else:
+        click.echo("Invalid input. Please provide an ENS name (e.g., 'vitalik.eth') or an Ethereum address (e.g., '0x...').", err=True)
+
+if __name__ == '__main__':
+    account_group()

--- a/analytics_commands.py
+++ b/analytics_commands.py
@@ -1,0 +1,97 @@
+import click
+import json # For pretty printing block/tx details
+
+@click.group('analytics')
+def analytics_group():
+    """Query blockchain state and trends."""
+    pass
+
+@analytics_group.command('gas')
+# Could add --source <oracle_name> if we support multiple gas oracles
+def get_gas_prices():
+    """Show current gas prices (slow, average, fast)."""
+    click.echo("Fetching current gas prices...")
+    # Placeholder: Implement gas price fetching (e.g., from eth_gasPrice or an oracle like EthGasStation/GasNow)
+    click.echo("Gas Prices (from ExampleOracle):")
+    click.echo("  Slow    : 30 Gwei")
+    click.echo("  Average : 45 Gwei (Recommended)")
+    click.echo("  Fast    : 60 Gwei")
+    click.echo("  Base Fee: 28 Gwei (EIP-1559)")
+    click.echo("  Next Base: 29 Gwei (EIP-1559)")
+
+
+@analytics_group.command('block')
+@click.argument('block_identifier', type=str, default='latest')
+@click.option('--full-tx', is_flag=True, help="Include full transaction objects instead of just hashes.")
+def get_block_details(block_identifier, full_tx):
+    """Show block details for a given block number or 'latest'."""
+    click.echo(f"Fetching details for block: {block_identifier}")
+    if full_tx:
+        click.echo("Including full transaction objects.")
+
+    # Placeholder: Implement block detail fetching (web3.eth.get_block)
+    example_block_data = {
+        "number": 12345678,
+        "hash": "0xBLOCKHASH...",
+        "parentHash": "0xPARENTBLOCKHASH...",
+        "timestamp": 1678886400,
+        "miner": "0xMINERADDRESS...",
+        "gasUsed": 15000000,
+        "gasLimit": 30000000,
+        "baseFeePerGas": "30000000000", # Wei
+        "transactions": ["0xTXHASH1...", "0xTXHASH2..."] if not full_tx else [
+            {"hash": "0xTXHASH1...", "from": "0xSENDER1", "to": "0xRECEIVER1", "value": "1000000000000000000"},
+            {"hash": "0xTXHASH2...", "from": "0xSENDER2", "to": "0xRECEIVER2", "value": "500000000000000000"}
+        ]
+    }
+    click.echo(json.dumps(example_block_data, indent=2))
+
+@analytics_group.command('tx')
+@click.argument('tx_hash', type=str)
+def get_transaction_details(tx_hash):
+    """Show detailed information for a specific transaction hash."""
+    click.echo(f"Fetching details for transaction: {tx_hash}")
+
+    # Placeholder: Implement transaction detail fetching (web3.eth.get_transaction and web3.eth.get_transaction_receipt)
+    example_tx_data = {
+        "hash": tx_hash,
+        "blockHash": "0xBLOCKHASH...",
+        "blockNumber": 12345678,
+        "from": "0xSENDERADDRESS...",
+        "to": "0xRECIPIENTADDRESS...",
+        "value": "1000000000000000000", # 1 ETH in Wei
+        "gas": 21000,
+        "gasPrice": "50000000000", # 50 Gwei in Wei
+        "nonce": 15,
+        "input": "0x" # or contract call data
+    }
+    example_receipt_data = {
+        "transactionHash": tx_hash,
+        "status": 1, # 1 for success, 0 for failure
+        "gasUsed": 21000,
+        "contractAddress": None, # or the address if it was a contract creation
+        "logs": [] # list of event logs
+    }
+    click.echo("Transaction Details:")
+    click.echo(json.dumps(example_tx_data, indent=2))
+    click.echo("\nTransaction Receipt:")
+    click.echo(json.dumps(example_receipt_data, indent=2))
+
+@analytics_group.command('addr')
+@click.argument('address', type=str)
+# This is a convenience command, combining info from other places.
+def get_address_info(address):
+    """Show basic info for an address: balance, tx count, tokens (summary)."""
+    click.echo(f"Fetching basic information for address: {address}")
+
+    # Placeholder: Combine calls to get balance, nonce, and a summary of tokens
+    # This would reuse logic from `account balance`, `account nonce`, and a simplified `account tokens`
+    click.echo(f"Address: {address}")
+    click.echo(f"  ETH Balance: 1.2345 ETH (Example)")
+    click.echo(f"  Nonce (Transaction Count): 42 (Example)")
+    click.echo(f"  Contract: {'Yes' if False else 'No'} (Placeholder - needs code size check)") # web3.eth.get_code(address) != '0x'
+    click.echo(f"  Token Summary: Holds 2 known ERC-20 tokens (DAI, USDC) (Example)")
+    click.echo(f"  ENS Name: vitalik.eth (Example, if reverse lookup successful)")
+
+if __name__ == '__main__':
+    analytics_group()

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,48 @@
+import click
+
+from network_commands import network_group
+from wallet_commands import wallet_group
+from tx_commands import tx_group
+from contract_commands import contract_group
+from compile_commands import compile_group
+from account_commands import account_group
+from analytics_commands import analytics_group
+from sign_commands import sign_group
+from sync_commands import sync_group
+from test_commands import test_group
+from config_commands import config_group
+from help_commands import help_group
+from export_commands import export_group
+from scan_commands import scan_group
+from nft_commands import nft_group
+# ... and so on for all other command groups
+
+@click.group()
+def ethcli():
+    """
+    Ethereum CLI Tool
+
+    A comprehensive command-line interface for interacting with the Ethereum blockchain,
+    managing wallets, deploying contracts, and more.
+    """
+    pass
+
+ethcli.add_command(network_group)
+ethcli.add_command(wallet_group)
+ethcli.add_command(tx_group)
+ethcli.add_command(contract_group)
+ethcli.add_command(compile_group)
+ethcli.add_command(account_group)
+ethcli.add_command(analytics_group)
+ethcli.add_command(sign_group)
+ethcli.add_command(sync_group)
+ethcli.add_command(test_group)
+ethcli.add_command(config_group)
+ethcli.add_command(help_group)
+ethcli.add_command(export_group)
+ethcli.add_command(scan_group)
+ethcli.add_command(nft_group)
+# ... and so on
+
+if __name__ == '__main__':
+    ethcli()

--- a/compile_commands.py
+++ b/compile_commands.py
@@ -1,0 +1,87 @@
+import click
+import json # For outputting ABI
+
+@click.group('compile')
+def compile_group():
+    """Compile Solidity contracts and manage build artifacts."""
+    pass
+
+@compile_group.command('sol')
+@click.argument('filepath', type=click.Path(exists=True, dir_okay=False))
+@click.option('--output-dir', type=click.Path(file_okay=False, dir_okay=True), help="Directory to save ABI and bytecode.")
+@click.option('--optimize', is_flag=True, help="Enable compiler optimization.")
+# We could add --solc-version, --evm-version etc. later
+def compile_solidity(filepath, output_dir, optimize):
+    """Compile a Solidity file (.sol) and output ABI + bytecode."""
+    click.echo(f"Compiling Solidity file: {filepath}")
+    if optimize:
+        click.echo("Compiler optimization enabled.")
+
+    # Placeholder: Implement actual Solidity compilation (e.g., using solcx or crytic-compile)
+    # 1. Read the .sol file.
+    # 2. Invoke the Solidity compiler.
+    # 3. Extract ABI and bytecode for each contract in the file.
+
+    example_contract_name = "MyContract" # Assume this is derived from the file or compilation output
+    example_abi = [{"type": "constructor", "inputs": []}, {"type": "function", "name": "greet", "outputs": [{"type": "string"}]}]
+    example_bytecode = "0x60806040..."
+
+    click.echo(f"--- {example_contract_name} ---")
+    click.echo("ABI:")
+    click.echo(json.dumps(example_abi, indent=2))
+    click.echo("\nBytecode:")
+    click.echo(example_bytecode)
+
+    if output_dir:
+        # Placeholder: Save ABI and bytecode to files in output_dir
+        # e.g., <output_dir>/MyContract.abi.json, <output_dir>/MyContract.bin
+        click.echo(f"\nSaving ABI and bytecode to directory: {output_dir}")
+        abi_path = f"{output_dir}/{example_contract_name}.abi.json"
+        bin_path = f"{output_dir}/{example_contract_name}.bin"
+        # with open(abi_path, 'w') as f: json.dump(example_abi, f, indent=2)
+        # with open(bin_path, 'w') as f: f.write(example_bytecode)
+        click.echo(f"ABI saved to: {abi_path} (Placeholder)")
+        click.echo(f"Bytecode saved to: {bin_path} (Placeholder)")
+
+    click.echo("\nCompilation successful (Placeholder).")
+
+
+@compile_group.command('ts')
+@click.argument('filepath', type=click.Path(exists=True, dir_okay=False))
+@click.option('--output-dir', type=click.Path(file_okay=False, dir_okay=True), default="./types", help="Directory to save generated TypeScript types.")
+# This assumes TypeChain is installed and configured
+def generate_typescript_types(filepath, output_dir):
+    """Generate TypeScript types from ABI (via TypeChain)."""
+    click.echo(f"Generating TypeScript types for contracts in: {filepath}")
+    click.echo(f"Output directory: {output_dir}")
+
+    # Placeholder: Implement TypeChain generation
+    # 1. Ensure ABIs are available (either compile first or point to existing ABIs).
+    # 2. Run TypeChain CLI tool.
+    click.echo("TypeChain command: typechain --target ethers-v5 --out-dir {output_dir} './build/contracts/*.json' (Example)")
+    click.echo(f"TypeScript types generated in {output_dir} (Placeholder).")
+
+@compile_group.command('verify')
+@click.argument('filepath', type=click.Path(exists=True, dir_okay=False))
+@click.option('--address', 'contract_address', required=True, type=str, help="Address of the deployed contract on Etherscan.")
+@click.option('--network', type=str, help="Network name (e.g., mainnet, goerli) for Etherscan verification. Defaults to current network.")
+# Potentially add --api-key for Etherscan
+# Add --constructor-args if needed for verification
+def verify_contract_etherscan(filepath, contract_address, network):
+    """Verify deployed contract source code on Etherscan."""
+    active_network = network or "current_network (e.g., mainnet)" # Placeholder for getting active network
+    click.echo(f"Verifying contract from file: {filepath}")
+    click.echo(f"Contract address: {contract_address}")
+    click.echo(f"Network for Etherscan: {active_network}")
+
+    # Placeholder: Implement Etherscan verification
+    # 1. Read contract source code.
+    # 2. Get compiler settings used for deployment (version, optimization).
+    # 3. (Optional) Flatten the source if it uses imports.
+    # 4. Send verification request to Etherscan API.
+    click.echo("Submitting source code to Etherscan for verification...")
+    click.echo("Verification successful. GUID: XYZ... (Placeholder)")
+    click.echo(f"Check status on Etherscan: https://{active_network.lower()}.etherscan.io/address/{contract_address}#code")
+
+if __name__ == '__main__':
+    compile_group()

--- a/config_commands.py
+++ b/config_commands.py
@@ -1,0 +1,158 @@
+import click
+import json
+import os
+
+# Define a default path for the configuration file
+# In a real app, use click.get_app_dir for platform-agnostic config location
+APP_NAME = "ethcli"
+CONFIG_DIR = click.get_app_dir(APP_NAME, force_posix=True) # Using force_posix for consistency in examples
+CONFIG_FILE = os.path.join(CONFIG_DIR, "config.json")
+
+# Default configuration settings
+DEFAULT_CONFIG = {
+    "default_network": "mainnet",
+    "default_wallet_alias": None,
+    "default_gas_limit": 2000000, # General purpose limit
+    "default_rpc_urls": {
+        "mainnet": "https://mainnet.infura.io/v3/YOUR_INFURA_PROJECT_ID", # User should replace this
+        "goerli": "https://goerli.infura.io/v3/YOUR_INFURA_PROJECT_ID",
+        "sepolia": "https://sepolia.infura.io/v3/YOUR_INFURA_PROJECT_ID",
+    },
+    "custom_networks": {}, # Stores user-added networks: name -> {rpc_url, chain_id (optional)}
+    "etherscan_api_key": None,
+}
+
+def load_config():
+    """Loads configuration from the JSON file."""
+    if not os.path.exists(CONFIG_FILE):
+        # If config doesn't exist, create it with defaults
+        save_config(DEFAULT_CONFIG)
+        return DEFAULT_CONFIG
+    try:
+        with open(CONFIG_FILE, 'r') as f:
+            return json.load(f)
+    except (json.JSONDecodeError, IOError) as e:
+        click.echo(f"Warning: Could not load config file at {CONFIG_FILE}. Using defaults. Error: {e}", err=True)
+        return DEFAULT_CONFIG.copy() # Return a copy to avoid modifying the global default
+
+def save_config(config_data):
+    """Saves configuration to the JSON file."""
+    try:
+        if not os.path.exists(CONFIG_DIR):
+            os.makedirs(CONFIG_DIR, exist_ok=True)
+        with open(CONFIG_FILE, 'w') as f:
+            json.dump(config_data, f, indent=2)
+    except IOError as e:
+        click.echo(f"Error: Could not save config file to {CONFIG_FILE}. Error: {e}", err=True)
+
+
+@click.group('config')
+def config_group():
+    """Manage global settings and preferences for ethcli."""
+    pass
+
+@config_group.command('set')
+@click.argument('key', type=str)
+@click.argument('value', type=str)
+def set_config_value(key, value):
+    """
+    Set a configuration value. Use dot notation for nested keys (e.g., default_rpc_urls.mainnet).
+
+    Examples:
+
+    ethcli config set default_network goerli
+
+    ethcli config set default_gas_limit 300000
+
+    ethcli config set default_rpc_urls.mainnet https://your-mainnet-rpc.com
+
+    ethcli config set etherscan_api_key YOUR_API_KEY
+    """
+    config = load_config()
+
+    # Handle nested keys
+    keys = key.split('.')
+    current_level = config
+
+    for i, k_part in enumerate(keys[:-1]):
+        if k_part not in current_level or not isinstance(current_level[k_part], dict):
+            # If path doesn't exist or is not a dict, create it or inform user
+            # For simplicity, we'll assume valid paths based on DEFAULT_CONFIG structure for now
+            # A more robust version would create nested dicts if they don't exist
+            click.echo(f"Error: Key path '{'.'.join(keys[:i+1])}' is not a valid dictionary in config.", err=True)
+            click.echo(f"You might need to set up the parent structure first or the key is invalid.")
+            return
+        current_level = current_level[k_part]
+
+    final_key = keys[-1]
+
+    # Attempt to cast value to a more appropriate type if possible
+    # This is a simple heuristic; a more complex system might use a schema
+    parsed_value = value
+    if value.lower() == "true":
+        parsed_value = True
+    elif value.lower() == "false":
+        parsed_value = False
+    elif value.lower() == "none" or value.lower() == "null":
+        parsed_value = None
+    else:
+        try:
+            parsed_value = int(value)
+        except ValueError:
+            try:
+                parsed_value = float(value)
+            except ValueError:
+                pass # Keep as string
+
+    current_level[final_key] = parsed_value
+    save_config(config)
+    click.echo(f"Configuration updated: {key} = {parsed_value}")
+    click.echo(f"Config file location: {CONFIG_FILE}")
+
+@config_group.command('get')
+@click.argument('key', type=str, required=False)
+def get_config_value(key):
+    """
+    Get a configuration value. Use dot notation for nested keys.
+    If no key is provided, shows the entire configuration.
+    """
+    config = load_config()
+    if not key:
+        click.echo("Current configuration:")
+        click.echo(json.dumps(config, indent=2))
+        click.echo(f"\nConfig file location: {CONFIG_FILE}")
+        return
+
+    keys = key.split('.')
+    current_level = config
+    try:
+        for k_part in keys:
+            current_level = current_level[k_part]
+        click.echo(f"{key} = {json.dumps(current_level, indent=2)}")
+    except KeyError:
+        click.echo(f"Error: Key '{key}' not found in configuration.", err=True)
+    except TypeError: # Could happen if trying to access sub-key of a non-dict
+        click.echo(f"Error: Cannot access sub-key of '{key}'. It might not be a dictionary.", err=True)
+
+
+@config_group.command('reset')
+@click.confirmation_option(prompt="Are you sure you want to reset all settings to their defaults?")
+def reset_config():
+    """Reset all settings to their default values."""
+    save_config(DEFAULT_CONFIG)
+    click.echo("Configuration has been reset to defaults.")
+    click.echo(json.dumps(DEFAULT_CONFIG, indent=2))
+    click.echo(f"\nConfig file location: {CONFIG_FILE}")
+
+@config_group.command('path')
+def config_path():
+    """Show the path to the configuration file."""
+    click.echo(f"Configuration file is located at: {CONFIG_FILE}")
+
+if __name__ == '__main__':
+    # For testing:
+    # Ensure the config directory and file are managed cleanly for tests
+    # For example, by using a temporary directory
+    # click.echo(f"Config file would be: {CONFIG_FILE}")
+    # config_group()
+    pass

--- a/contract_commands.py
+++ b/contract_commands.py
@@ -1,0 +1,139 @@
+import click
+import json # For handling args if they are passed as JSON
+
+@click.group('contract')
+def contract_group():
+    """Deploy, interact with, and inspect smart contracts."""
+    pass
+
+@contract_group.command('deploy')
+@click.argument('filepath', type=click.Path(exists=True, dir_okay=False))
+@click.option('--constructor-args', 'constructor_args_str', type=str, help="Comma-separated constructor arguments or JSON string.")
+# Add options for gas, nonce, etc. later
+def deploy_contract(filepath, constructor_args_str):
+    """Deploy a contract from a .sol file."""
+    click.echo(f"Deploying contract from file: {filepath}")
+
+    args_to_pass = []
+    if constructor_args_str:
+        # Try to parse as JSON array first
+        try:
+            args_to_pass = json.loads(constructor_args_str)
+            if not isinstance(args_to_pass, list):
+                # If it's valid JSON but not an array, treat as comma-separated
+                raise json.JSONDecodeError("Not a JSON array", constructor_args_str, 0)
+            click.echo(f"Using constructor arguments (JSON): {args_to_pass}")
+        except json.JSONDecodeError:
+            args_to_pass = [arg.strip() for arg in constructor_args_str.split(',')]
+            click.echo(f"Using constructor arguments (comma-separated): {args_to_pass}")
+
+    # Placeholder: Implement contract compilation (if not already compiled),
+    # then deployment. This would involve:
+    # 1. Reading the .sol file.
+    # 2. Compiling it to get ABI and bytecode (perhaps using a compile command).
+    # 3. Estimating gas for deployment.
+    # 4. Sending the deployment transaction.
+    # 5. Waiting for receipt and getting contract address.
+    click.echo(f"Contract '{filepath}' submitted for deployment with args: {args_to_pass}")
+    click.echo("Deployment transaction hash: 0xDEPLOYMENTHASH...")
+    click.echo("Contract deployed at address: 0xCONTRACTADDRESS...")
+
+@contract_group.command('call')
+@click.option('--address', 'contract_address', required=True, type=str, help="Address of the contract.")
+@click.option('--method', 'method_signature', required=True, type=str, help="Method signature (e.g., 'balanceOf(address)').")
+@click.option('--args', 'method_args_str', type=str, help="Comma-separated arguments or JSON string for the method call.")
+# We might need --abi <path_to_abi_file_or_etherscan_lookup_flag>
+def call_contract_method(contract_address, method_signature, method_args_str):
+    """Call a read-only (view/pure) function on a contract."""
+    click.echo(f"Calling method '{method_signature}' on contract: {contract_address}")
+
+    args_to_pass = []
+    if method_args_str:
+        try:
+            args_to_pass = json.loads(method_args_str)
+            if not isinstance(args_to_pass, list):
+                raise json.JSONDecodeError("Not a JSON array", method_args_str, 0)
+            click.echo(f"With arguments (JSON): {args_to_pass}")
+        except json.JSONDecodeError:
+            args_to_pass = [arg.strip() for arg in method_args_str.split(',')]
+            click.echo(f"With arguments (comma-separated): {args_to_pass}")
+
+    # Placeholder: Implement read-only contract call logic
+    # 1. Need ABI for the contract (fetch from stored location, file, or Etherscan).
+    # 2. Encode the function call with arguments.
+    # 3. Use eth_call to get the result.
+    # 4. Decode the result.
+    click.echo(f"Result of calling '{method_signature}' with args {args_to_pass}: ... (result data)")
+
+@contract_group.command('send')
+@click.option('--address', 'contract_address', required=True, type=str, help="Address of the contract.")
+@click.option('--method', 'method_signature', required=True, type=str, help="Method signature (e.g., 'transfer(address,uint256)').")
+@click.option('--args', 'method_args_str', type=str, help="Comma-separated arguments or JSON string for the method.")
+@click.option('--value', type=str, help="ETH value to send with the transaction (e.g., 0.1eth).")
+# Add options for gas, nonce, etc.
+def send_contract_transaction(contract_address, method_signature, method_args_str, value):
+    """Send a transaction to a write function on a contract."""
+    click.echo(f"Sending transaction for method '{method_signature}' to contract: {contract_address}")
+
+    args_to_pass = []
+    if method_args_str:
+        try:
+            args_to_pass = json.loads(method_args_str)
+            if not isinstance(args_to_pass, list):
+                raise json.JSONDecodeError("Not a JSON array", method_args_str, 0)
+            click.echo(f"With arguments (JSON): {args_to_pass}")
+        except json.JSONDecodeError:
+            args_to_pass = [arg.strip() for arg in method_args_str.split(',')]
+            click.echo(f"With arguments (comma-separated): {args_to_pass}")
+
+    if value:
+        click.echo(f"Sending {value} ETH with the transaction.")
+
+    # Placeholder: Implement write transaction to contract
+    # 1. Need ABI.
+    # 2. Encode function call with arguments.
+    # 3. Estimate gas.
+    # 4. Build, sign, and send the transaction.
+    click.echo(f"Transaction for '{method_signature}' with args {args_to_pass} submitted. Hash: 0xCONTRACTTXHASH...")
+
+@contract_group.command('abi')
+@click.option('--address', 'contract_address', required=True, type=str, help="Address of the contract.")
+# Could add --save <filepath> or --etherscan-lookup flags
+def get_contract_abi(contract_address):
+    """Fetch or view ABI of a deployed contract."""
+    click.echo(f"Fetching ABI for contract: {contract_address}")
+    # Placeholder: Implement ABI fetching logic (e.g., from Etherscan or local storage)
+    example_abi_fragment = [
+        {"type": "function", "name": "balanceOf", "inputs": [{"name": "owner", "type": "address"}], "outputs": [{"name": "", "type": "uint256"}], "stateMutability": "view"},
+        {"type": "event", "name": "Transfer", "inputs": [{"indexed": True, "name": "from", "type": "address"}]}
+    ]
+    click.echo(json.dumps(example_abi_fragment, indent=2))
+
+@contract_group.command('events')
+@click.option('--address', 'contract_address', required=True, type=str, help="Address of the contract.")
+@click.option('--event-name', type=str, help="Specific event name to listen for (optional).")
+@click.option('--from-block', type=str, help="Start block for fetching past events (e.g., 'latest', number, or 'earliest').")
+@click.option('--live', is_flag=True, help="Listen for live events (streams).")
+def contract_events(contract_address, event_name, from_block, live):
+    """Listen to or show emitted events from a contract."""
+    action = "Listening for live" if live else "Fetching past"
+    click.echo(f"{action} events for contract: {contract_address}")
+    if event_name:
+        click.echo(f"Filtering for event: {event_name}")
+    if from_block:
+        click.echo(f"Starting from block: {from_block}")
+
+    # Placeholder: Implement event fetching/listening logic
+    if live:
+        click.echo("Streaming live events (Ctrl+C to stop)...")
+        # Placeholder: web3.py event filter loop
+    else:
+        click.echo("Example Past Event:")
+        click.echo(json.dumps({
+            "event": "Transfer",
+            "args": {"from": "0xSENDER", "to": "0xRECEIVER", "value": 100},
+            "blockNumber": 123450
+        }, indent=2))
+
+if __name__ == '__main__':
+    contract_group()

--- a/export_commands.py
+++ b/export_commands.py
@@ -1,0 +1,176 @@
+import click
+import json
+import csv # For CSV export
+import io # For CSV writing to string then to file if needed
+
+# Helper function to handle output (print to console or save to file)
+def _handle_output(data_str, output_file, default_filename="export.txt"):
+    if output_file:
+        try:
+            with open(output_file, 'w') as f:
+                f.write(data_str)
+            click.echo(f"Data successfully exported to: {output_file}")
+        except IOError as e:
+            click.echo(f"Error writing to file {output_file}: {e}", err=True)
+    else:
+        click.echo(data_str)
+
+# Helper to convert list of dicts to CSV string
+def _to_csv_string(data_list_of_dicts, fieldnames):
+    if not data_list_of_dicts:
+        return ""
+    # Ensure all fieldnames are present, even if some dicts don't have them
+    # This also preserves order of columns if fieldnames is provided.
+    # If fieldnames is None, it will be derived from the first item.
+    if fieldnames is None and data_list_of_dicts:
+        fieldnames = list(data_list_of_dicts[0].keys())
+
+    output = io.StringIO()
+    writer = csv.DictWriter(output, fieldnames=fieldnames, extrasaction='ignore')
+    writer.writeheader()
+    writer.writerows(data_list_of_dicts)
+    return output.getvalue()
+
+
+@click.group('export')
+@click.option('--output-file', '-o', type=click.Path(dir_okay=False, writable=True), help="File to save the exported data. If not provided, prints to console.")
+@click.pass_context # To pass options like output_file to subcommands if needed
+def export_group(ctx, output_file):
+    """Export data such as wallets, transactions, or contract details."""
+    ctx.obj = {} # Create a context object
+    ctx.obj['output_file'] = output_file # Store output_file in context
+
+@export_group.command('wallets')
+@click.option('--format', 'export_format', type=click.Choice(['json', 'csv'], case_sensitive=False), default='json', help="Format for the exported data.")
+@click.pass_context
+def export_wallets(ctx, export_format):
+    """Export stored wallet information (addresses, names, NOT private keys)."""
+    output_file = ctx.obj.get('output_file')
+    click.echo("Exporting stored wallet information...")
+
+    # Placeholder: Fetch wallet data (similar to `wallet list` but structured for export)
+    # IMPORTANT: This should NEVER export private keys by default or without explicit, strong warnings.
+    # For this example, we'll assume we only export non-sensitive data.
+    wallets_data = [
+        {"alias": "my_main_wallet", "address": "0xADDRESS_MAIN_WALLET_HERE", "type": "local"},
+        {"alias": "imported_hardware", "address": "0xADDRESS_HW_WALLET_HERE", "type": "hardware_stub"},
+        {"alias": "burner1", "address": "0xADDRESS_BURNER1_WALLET_HERE", "type": "local"},
+    ] # This data would come from the wallet management system.
+
+    if not wallets_data:
+        click.echo("No wallets found to export.")
+        return
+
+    output_str = ""
+    default_filename = f"wallets_export.{export_format}"
+
+    if export_format == 'json':
+        output_str = json.dumps(wallets_data, indent=2)
+    elif export_format == 'csv':
+        # Define CSV headers carefully
+        fieldnames = ["alias", "address", "type"]
+        output_str = _to_csv_string(wallets_data, fieldnames)
+
+    _handle_output(output_str, output_file, default_filename)
+
+
+@export_group.command('transactions')
+@click.option('--address', 'target_address', type=str, help="Export transactions for a specific address (defaults to active wallet).")
+@click.option('--from-block', type=str, help="Start block for transaction history.")
+@click.option('--to-block', type=str, default='latest', help="End block for transaction history.")
+@click.option('--format', 'export_format', type=click.Choice(['json', 'csv'], case_sensitive=False), default='csv', help="Format for the exported data.")
+# Could add --include-internal to fetch internal transactions if supported by provider
+@click.pass_context
+def export_transactions(ctx, target_address, from_block, to_block, export_format):
+    """Export transaction history for an address or within a block range."""
+    output_file = ctx.obj.get('output_file')
+
+    # Placeholder: Determine target address (e.g., from active wallet or --address)
+    addr_to_query = target_address or "0xACTIVE_WALLET_OR_SPECIFIED_ADDRESS"
+    click.echo(f"Exporting transactions for address: {addr_to_query}")
+    click.echo(f"Block range: {from_block or 'genesis'} to {to_block}")
+
+    # Placeholder: Implement transaction fetching logic.
+    # This would typically involve:
+    # 1. Connecting to an Ethereum node or Etherscan-like API.
+    # 2. Paginating through transactions for the given address and block range.
+    # 3. Formatting each transaction into a dictionary.
+    transactions_data = [
+        {"hash": "0xTXHASH1...", "blockNumber": 12345, "timestamp": 1600000000, "from": addr_to_query, "to": "0xRECIPIENT1", "value_eth": "0.1", "gas_used": 21000, "status": "success"},
+        {"hash": "0xTXHASH2...", "blockNumber": 12360, "timestamp": 1600005000, "from": "0xSENDER2", "to": addr_to_query, "value_eth": "0.5", "gas_used": 55000, "status": "success"},
+        {"hash": "0xTXHASH3...", "blockNumber": 12390, "timestamp": 1600010000, "from": addr_to_query, "to": "0xCONTRACT_ADDRESS", "value_eth": "0.0", "gas_used": 150000, "status": "failure", "method": "approve(address,uint256)"},
+    ] # Example data
+
+    if not transactions_data:
+        click.echo("No transactions found for the given criteria.")
+        return
+
+    output_str = ""
+    default_filename = f"transactions_{addr_to_query.replace('0x','')[0:8]}_{from_block or 'start'}-{to_block}.{export_format}"
+
+    if export_format == 'json':
+        output_str = json.dumps(transactions_data, indent=2)
+    elif export_format == 'csv':
+        # Define CSV headers
+        fieldnames = ["hash", "blockNumber", "timestamp", "from", "to", "value_eth", "gas_used", "status", "method"]
+        output_str = _to_csv_string(transactions_data, fieldnames)
+
+    _handle_output(output_str, output_file, default_filename)
+
+
+@export_group.command('contracts')
+@click.option('--verified-only', is_flag=True, help="Only export contracts with verified source code (if data source supports this).")
+@click.option('--format', 'export_format', type=click.Choice(['json', 'csv'], case_sensitive=False), default='json', help="Format for the exported data.")
+# Could add --min-tx-count or --min-balance to filter
+@click.pass_context
+def export_contracts(ctx, verified_only, export_format):
+    """Export a list of known/interacted smart contracts (metadata)."""
+    output_file = ctx.obj.get('output_file')
+    click.echo("Exporting smart contract information...")
+    if verified_only:
+        click.echo("Filtering for verified contracts only.")
+
+    # Placeholder: Implement contract data fetching.
+    # This is complex and would likely rely on:
+    # 1. An indexed database of contracts (e.g., from Dune Analytics, Etherscan).
+    # 2. Or, analysis of the active wallet's transaction history to find interacted contract addresses.
+    contracts_data = [
+        {"address": "0xCONTRACT1...", "name": "MyToken", "symbol": "MTK", "compiler": "Solidity v0.8.7", "verified": True, "creation_tx": "0xCREATIONTX1...", "creator": "0xCREATOR1..."},
+        {"address": "0xCONTRACT2...", "name": "AnotherProtocol", "symbol": None, "compiler": "Vyper v0.3.1", "verified": True, "creation_tx": "0xCREATIONTX2...", "creator": "0xCREATOR2..."},
+        {"address": "0xCONTRACT3...", "name": "UnverifiedContract", "symbol": None, "compiler": None, "verified": False, "creation_tx": "0xCREATIONTX3...", "creator": "0xCREATOR3..."},
+    ]
+
+    if verified_only:
+        contracts_data = [c for c in contracts_data if c.get("verified")]
+
+    if not contracts_data:
+        click.echo("No contracts found to export with the given criteria.")
+        return
+
+    output_str = ""
+    default_filename = f"contracts_export.{export_format}"
+
+    if export_format == 'json':
+        output_str = json.dumps(contracts_data, indent=2)
+    elif export_format == 'csv':
+        fieldnames = ["address", "name", "symbol", "compiler", "verified", "creation_tx", "creator"]
+        output_str = _to_csv_string(contracts_data, fieldnames)
+
+    _handle_output(output_str, output_file, default_filename)
+
+
+if __name__ == '__main__':
+    # To test:
+    # python export_commands.py wallets -o wallets.json
+    # python export_commands.py transactions --address 0xYourAddress -o txs.csv --format csv
+    # Create a dummy context for testing if run directly
+    class DummyContext:
+        def __init__(self):
+            self.obj = {}
+
+    ctx = DummyContext()
+    ctx.obj['output_file'] = None # Simulate no -o option initially
+
+    # Example of how you might call it programmatically for testing (requires more setup)
+    # export_group.main(args=['wallets', '--format', 'csv', '-o', 'mywallets.csv'], standalone_mode=False, obj=ctx)
+    pass

--- a/help_commands.py
+++ b/help_commands.py
@@ -1,0 +1,135 @@
+import click
+
+# Note: 'click' automatically provides 'ethcli --help', 'ethcli <group> --help',
+# and 'ethcli <group> <command> --help'.
+# This 'help' group is primarily for custom extensions like 'examples'.
+
+@click.group('help')
+def help_group():
+    """
+    Provides extended help and examples for using ethcli.
+    For standard help, use 'ethcli --help' or 'ethcli <command> --help'.
+    """
+    pass
+
+@help_group.command('examples')
+@click.option('--command', 'specific_command', type=str, help="Show examples for a specific command or group (e.g., 'wallet create', 'tx send').")
+def show_examples(specific_command):
+    """Print common usage examples for ethcli commands."""
+
+    examples = {
+        "general": [
+            "# Show top-level help:",
+            "ethcli --help",
+            "# Show help for the 'wallet' command group:",
+            "ethcli wallet --help",
+            "# Show help for the 'wallet create' command:",
+            "ethcli wallet create --help",
+        ],
+        "network": [
+            "# List available networks:",
+            "ethcli network list",
+            "# Switch to the Goerli testnet:",
+            "ethcli network use goerli",
+            "# Add a custom network:",
+            "ethcli network add my_local_node --rpc http://localhost:8545",
+            "# Show info about the current network:",
+            "ethcli network info",
+        ],
+        "wallet": [
+            "# Create a new wallet with an alias:",
+            "ethcli wallet create --name my_main_wallet",
+            "# List all stored wallets:",
+            "ethcli wallet list",
+            "# Import a wallet using a private key (use quotes for safety):",
+            'ethcli wallet import --private-key "0xYOUR_PRIVATE_KEY_HERE"',
+            "# Export a wallet's address (private key hidden by default):",
+            "ethcli wallet export my_main_wallet",
+            "# Export a wallet and show its private key (USE WITH EXTREME CAUTION):",
+            "ethcli wallet export my_main_wallet --show-private",
+        ],
+        "tx": [
+            "# Send 0.5 ETH to an address (ensure active network and wallet are set):",
+            "ethcli tx send --to 0xRecipientAddress... --value 0.5eth",
+            "# Check the status of a transaction:",
+            "ethcli tx status 0xTransactionHash...",
+            "# Estimate gas for a transaction:",
+            "ethcli tx gas-estimate --to 0xRecipientAddress... --value 0.1eth",
+        ],
+        "contract": [
+            "# Deploy a smart contract (assuming MyContract.sol exists):",
+            'ethcli contract deploy ./contracts/MyContract.sol --constructor-args \'123,"hello",0xSomeAddress\'',
+            "# Call a read-only method on a deployed contract:",
+            "ethcli contract call --address 0xContractAddress... --method 'balanceOf(address)' --args '0xAccountToQuery'",
+            "# Send a transaction to a write method on a contract:",
+            "ethcli contract send --address 0xContractAddress... --method 'transfer(address,uint256)' --args '0xRecipientAddress,1000000000000000000' --value 0.01eth",
+            "# Get a contract's ABI:",
+            "ethcli contract abi --address 0xContractAddress...",
+        ],
+        "account": [
+            "# Check ETH balance of the active wallet:",
+            "ethcli account balance",
+            "# Check ETH balance of a specific address:",
+            "ethcli account balance --address 0xSomeAddress...",
+            "# Check balance of an ERC20 token for the active wallet:",
+            "ethcli account balance --token 0xTokenContractAddress...",
+            "# Get the nonce for the active wallet:",
+            "ethcli account nonce",
+            "# Resolve an ENS name to an address:",
+            "ethcli account ens vitalik.eth",
+        ],
+        "nft": [
+            "# Deploy an ERC-721 NFT contract (assuming MyNFT.sol for ERC721 exists):",
+            'ethcli nft deploy721 ./contracts/MyNFT.sol --name "My Awesome NFT" --symbol "MANFT"',
+            "# Mint an ERC-721 token:",
+            "ethcli nft mint721 --to 0xRecipientAddress... --uri ipfs://YourMetadataHash --contract 0xNftContractAddress...",
+            "# Get the owner of an ERC-721 token:",
+            "ethcli nft owner721 --id 1 --contract 0xNftContractAddress...",
+        ],
+        "config": [
+            "# Show all current configurations:",
+            "ethcli config get",
+            "# Set the default network to sepolia:",
+            "ethcli config set default_network sepolia",
+            "# Get the path to the config file:",
+            "ethcli config path",
+        ]
+        # Add more examples for other groups as needed
+    }
+
+    if specific_command:
+        # Try to find examples for the specific command/group
+        # This is a simple match; could be more sophisticated (e.g. matching "tx" for "tx send")
+        matched = False
+        for key, ex_list in examples.items():
+            if key == specific_command or specific_command.startswith(key):
+                click.echo(f"\n--- Examples for '{key}' ---")
+                for ex in ex_list:
+                    click.echo(ex)
+                matched = True
+        if not matched:
+            click.echo(f"No specific examples found for '{specific_command}'. Showing general examples.")
+            if "general" in examples: # Check if general examples exist
+                 for ex in examples["general"]:
+                    click.echo(ex)
+    else:
+        click.echo("--- Common ethcli Usage Examples ---")
+        click.echo("For detailed help on any command: ethcli <command_group> <sub_command> --help\n")
+        for group_name, ex_list in examples.items():
+            if group_name == "general": continue # Skip general if showing all
+            click.echo(f"\n--- {group_name.capitalize()} Examples ---")
+            for i, ex in enumerate(ex_list):
+                click.echo(ex)
+                if i >= 2 and len(ex_list) > 3: # Show first 3 for brevity when listing all
+                    click.echo(f"(... and {len(ex_list) - 3} more for {group_name} ...)")
+                    break
+
+        click.echo("\n--- General Help Examples ---")
+        if "general" in examples: # Check if general examples exist
+            for ex in examples["general"]:
+                click.echo(ex)
+
+if __name__ == '__main__':
+    # To test: python help_commands.py examples
+    # python help_commands.py examples --command wallet
+    help_group()

--- a/network_commands.py
+++ b/network_commands.py
@@ -1,0 +1,51 @@
+import click
+
+@click.group('network')
+def network_group():
+    """Manage and view Ethereum networks."""
+    pass
+
+@network_group.command('list')
+def list_networks():
+    """Show available networks."""
+    click.echo("Listing available networks...")
+    # Placeholder: Implement actual network listing logic
+    click.echo("- mainnet")
+    click.echo("- goerli")
+    click.echo("- sepolia")
+
+@network_group.command('use')
+@click.argument('network_name', type=str)
+def use_network(network_name):
+    """Switch active network (mainnet, goerli, sepolia, etc.)."""
+    click.echo(f"Switching active network to: {network_name}")
+    # Placeholder: Implement network switching logic
+
+@network_group.command('add')
+@click.argument('name', type=str)
+@click.option('--rpc', 'rpc_url', required=True, type=str, help="RPC URL of the custom network.")
+def add_network(name, rpc_url):
+    """Add a custom network."""
+    click.echo(f"Adding custom network '{name}' with RPC URL: {rpc_url}")
+    # Placeholder: Implement custom network addition logic
+
+@network_group.command('remove')
+@click.argument('name', type=str)
+def remove_network(name):
+    """Remove a network."""
+    click.echo(f"Removing network: {name}")
+    # Placeholder: Implement network removal logic
+
+@network_group.command('info')
+def network_info():
+    """Show current network info (chain ID, gas price, peers)."""
+    click.echo("Displaying current network information...")
+    # Placeholder: Implement logic to fetch and display network info
+    click.echo("Chain ID: 1 (Example Mainnet)")
+    click.echo("Current Gas Price: 50 Gwei")
+    click.echo("Connected Peers: 10")
+
+if __name__ == '__main__':
+    # This allows testing the command group independently, if necessary
+    # For example: python network_commands.py list
+    network_group()

--- a/nft_commands.py
+++ b/nft_commands.py
@@ -1,0 +1,321 @@
+import click
+import json # For metadata display or complex args
+
+# Assume we have helper functions to interact with contracts (similar to contract_commands.py)
+# For brevity, these will be high-level placeholders here.
+# e.g., call_contract_method(address, method_sig, args) -> result
+# e.g., send_contract_tx(address, method_sig, args, value) -> tx_hash
+
+def placeholder_call_contract(contract_address, method_signature, args_list):
+    args_str = ", ".join(map(str, args_list))
+    click.echo(f"SIMULATING: Call '{method_signature}({args_str})' on {contract_address}")
+    if "ownerOf" in method_signature: return f"0xOWNER_ADDRESS_OF_TOKEN_{args_list[0]}"
+    if "tokenURI" in method_signature or "uri" in method_signature : return f"ipfs://METADATA_URI_FOR_TOKEN_{args_list[0]}"
+    if "balanceOf" in method_signature and len(args_list) == 2 : return 5 # ERC1155 balance
+    if "balanceOf" in method_signature and len(args_list) == 1 : return 3 # ERC721 balance for an owner
+    if "symbol" in method_signature: return "NFTsmbl"
+    if "name" in method_signature: return "NFTName"
+    return "Placeholder contract call result"
+
+def placeholder_send_contract_tx(contract_address, method_signature, args_list, value_eth=None):
+    args_str = ", ".join(map(str, args_list))
+    value_info = f" with {value_eth} ETH" if value_eth else ""
+    tx_hash = f"0xSIMULATED_NFT_TX_HASH_{method_signature.split('(')[0]}"
+    click.echo(f"SIMULATING: Send TX for '{method_signature}({args_str})' to {contract_address}{value_info}. TxHash: {tx_hash}")
+    return tx_hash
+
+def placeholder_deploy_contract(contract_sol_path, constructor_args_list, contract_type_name):
+    args_str = ", ".join(map(str, constructor_args_list))
+    deployed_address = f"0xDEPLOYED_{contract_type_name.upper()}_CONTRACT_ADDRESS"
+    click.echo(f"SIMULATING: Deploying {contract_type_name} from {contract_sol_path} with args ({args_str}). Address: {deployed_address}")
+    return deployed_address
+
+
+@click.group('nft')
+def nft_group():
+    """Create, manage, and interact with ERC-721 and ERC-1155 NFTs."""
+    pass
+
+# --- NFT Deployment ---
+@nft_group.command('deploy721')
+@click.argument('contract_filepath', type=click.Path(exists=True, dir_okay=False))
+@click.option('--name', required=True, help="Name of the ERC-721 token (e.g., 'My Cool Cats').")
+@click.option('--symbol', required=True, help="Symbol of the ERC-721 token (e.g., 'MCC').")
+# Standard ERC721 constructor often takes name and symbol.
+# More complex contracts might need --constructor-args like in general contract deploy
+def deploy_erc721(contract_filepath, name, symbol):
+    """Deploy an ERC-721 contract from a .sol file."""
+    click.echo(f"Preparing to deploy ERC-721 contract: {name} ({symbol}) from {contract_filepath}")
+    # Actual deployment would involve compiling, then sending a transaction with bytecode and constructor args.
+    # Constructor for a typical OpenZeppelin ERC721 is (string name, string symbol)
+    constructor_args = [name, symbol]
+    deployed_address = placeholder_deploy_contract(contract_filepath, constructor_args, "ERC721")
+    click.echo(f"ERC-721 Contract '{name}' deployment submitted. Estimated address: {deployed_address}")
+
+@nft_group.command('deploy1155')
+@click.argument('contract_filepath', type=click.Path(exists=True, dir_okay=False))
+@click.option('--uri', 'default_uri_template', required=True, help="Default URI template for ERC-1155 tokens (e.g., 'ipfs://{id}.json').")
+# Standard ERC1155 constructor often takes a URI.
+def deploy_erc1155(contract_filepath, default_uri_template):
+    """Deploy an ERC-1155 contract from a .sol file."""
+    click.echo(f"Preparing to deploy ERC-1155 contract from {contract_filepath} with URI: {default_uri_template}")
+    # Constructor for a typical OpenZeppelin ERC1155 is (string uri)
+    constructor_args = [default_uri_template]
+    deployed_address = placeholder_deploy_contract(contract_filepath, constructor_args, "ERC1155")
+    click.echo(f"ERC-1155 Contract deployment submitted. Estimated address: {deployed_address}")
+
+# --- NFT Minting ---
+@nft_group.command('mint721')
+@click.option('--to', 'recipient_address', required=True, help="Address to mint the ERC-721 token to.")
+@click.option('--uri', 'metadata_uri', required=True, help="Metadata URI for the new token (e.g., ipfs://... or https://...).")
+@click.option('--contract', 'contract_address', required=True, help="Address of the deployed ERC-721 contract.")
+@click.option('--token-id', type=int, help="Specify token ID if contract allows (otherwise auto-assigned or not needed for mint call). Some contracts auto-increment, others require it.")
+def mint_erc721(recipient_address, metadata_uri, contract_address, token_id):
+    """Mint a new ERC-721 token. Assumes contract has a compatible mint function."""
+    click.echo(f"Minting ERC-721 token on contract {contract_address}:")
+    click.echo(f"  To: {recipient_address}")
+    click.echo(f"  Metadata URI: {metadata_uri}")
+    if token_id is not None: # Some mint functions take tokenID, others generate it.
+        click.echo(f"  Token ID: {token_id}")
+        # Example: safeMint(address to, uint256 tokenId, string memory uri) - less common for external URI setting
+        # More common: safeMint(address to, uint256 tokenId) and a separate setTokenURI(uint256 tokenId, string memory _tokenURI)
+        # Or safeMint(address to, string memory uri) if IDs are auto-generated and URI is set at mint.
+        # This placeholder assumes a mint function like: mint(to, tokenId, uri) or mint(to, uri) if tokenId is optional/auto
+        placeholder_send_contract_tx(contract_address, f"safeMint(address,uint256,string)", [recipient_address, token_id, metadata_uri])
+    else:
+        # Assuming a common pattern like: safeMint(address to, string memory uri)
+        placeholder_send_contract_tx(contract_address, f"safeMint(address,string)", [recipient_address, metadata_uri])
+    click.echo("ERC-721 mint transaction submitted.")
+
+
+@nft_group.command('mint1155')
+@click.option('--to', 'recipient_address', required=True, help="Address to mint the ERC-1155 token(s) to.")
+@click.option('--id', 'token_id', required=True, type=int, help="ID of the token type to mint.")
+@click.option('--amount', required=True, type=int, help="Amount of tokens to mint.")
+@click.option('--contract', 'contract_address', required=True, help="Address of the deployed ERC-1155 contract.")
+@click.option('--data', 'tx_data', default="0x", help="Additional data field for the mint function (hex string).")
+# ERC1155 mint function: mint(address to, uint256 id, uint256 amount, bytes data)
+def mint_erc1155(recipient_address, token_id, amount, contract_address, tx_data):
+    """Mint ERC-1155 token(s)."""
+    click.echo(f"Minting {amount} of ERC-1155 token ID {token_id} on contract {contract_address}:")
+    click.echo(f"  To: {recipient_address}")
+    click.echo(f"  Data: {tx_data}")
+    args = [recipient_address, token_id, amount, tx_data]
+    placeholder_send_contract_tx(contract_address, "mint(address,uint256,uint256,bytes)", args)
+    click.echo("ERC-1155 mint transaction submitted.")
+
+# --- NFT Transfers ---
+@nft_group.command('transfer721')
+@click.option('--from', 'from_address', required=True, help="Address to transfer the token from (must be owner or approved).")
+@click.option('--to', 'to_address', required=True, help="Address to transfer the token to.")
+@click.option('--id', 'token_id', required=True, type=int, help="ID of the ERC-721 token to transfer.")
+@click.option('--contract', 'contract_address', required=True, help="Address of the ERC-721 contract.")
+# ERC721 transfer: safeTransferFrom(address from, address to, uint256 tokenId)
+def transfer_erc721(from_address, to_address, token_id, contract_address):
+    """Transfer ownership of an ERC-721 token."""
+    click.echo(f"Transferring ERC-721 token ID {token_id} from {from_address} to {to_address} on contract {contract_address}")
+    args = [from_address, to_address, token_id]
+    placeholder_send_contract_tx(contract_address, "safeTransferFrom(address,address,uint256)", args)
+    click.echo("ERC-721 transfer transaction submitted.")
+
+@nft_group.command('transfer1155')
+@click.option('--from', 'from_address', required=True, help="Address to transfer token(s) from.")
+@click.option('--to', 'to_address', required=True, help="Address to transfer token(s) to.")
+@click.option('--id', 'token_id', required=True, type=int, help="ID of the ERC-1155 token type.")
+@click.option('--amount', required=True, type=int, help="Amount of tokens to transfer.")
+@click.option('--contract', 'contract_address', required=True, help="Address of the ERC-1155 contract.")
+@click.option('--data', 'tx_data', default="0x", help="Additional data field for the transfer function (hex string).")
+# ERC1155 transfer: safeTransferFrom(address from, address to, uint256 id, uint256 amount, bytes data)
+def transfer_erc1155(from_address, to_address, token_id, amount, contract_address, tx_data):
+    """Transfer ERC-1155 token(s)."""
+    click.echo(f"Transferring {amount} of ERC-1155 token ID {token_id} from {from_address} to {to_address} on contract {contract_address}")
+    args = [from_address, to_address, token_id, amount, tx_data]
+    placeholder_send_contract_tx(contract_address, "safeTransferFrom(address,address,uint256,uint256,bytes)", args)
+    click.echo("ERC-1155 transfer transaction submitted.")
+
+# --- NFT Metadata and Ownership ---
+@nft_group.command('owner721')
+@click.option('--id', 'token_id', required=True, type=int, help="ID of the ERC-721 token.")
+@click.option('--contract', 'contract_address', required=True, help="Address of the ERC-721 contract.")
+def get_owner_erc721(token_id, contract_address):
+    """Get the owner of a specific ERC-721 token."""
+    click.echo(f"Fetching owner of ERC-721 token ID {token_id} from contract {contract_address}")
+    owner = placeholder_call_contract(contract_address, "ownerOf(uint256)", [token_id])
+    click.echo(f"Owner of token {token_id}: {owner}")
+
+@nft_group.command('balance1155') # Changed from owner1155 to balance1155 for clarity
+@click.option('--owner', 'owner_address', required=True, help="Address of the owner/wallet.")
+@click.option('--id', 'token_id', required=True, type=int, help="ID of the ERC-1155 token type.")
+@click.option('--contract', 'contract_address', required=True, help="Address of the ERC-1155 contract.")
+def get_balance_erc1155(owner_address, token_id, contract_address):
+    """Check balance (quantity) of an ERC-1155 token for a specific owner and token ID."""
+    click.echo(f"Fetching balance of ERC-1155 token ID {token_id} for owner {owner_address} from contract {contract_address}")
+    balance = placeholder_call_contract(contract_address, "balanceOf(address,uint256)", [owner_address, token_id])
+    click.echo(f"Balance of token {token_id} for {owner_address}: {balance}")
+
+@nft_group.command('uri')
+@click.option('--id', 'token_id', required=True, type=int, help="Token ID to fetch metadata URI for.")
+@click.option('--contract', 'contract_address', required=True, help="Address of the NFT contract (ERC-721 or ERC-1155).")
+# ERC721: tokenURI(uint256 tokenId)
+# ERC1155: uri(uint256 id)
+def get_token_uri(token_id, contract_address):
+    """Fetch token metadata URI (works for both ERC-721 tokenURI and ERC-1155 uri)."""
+    click.echo(f"Fetching metadata URI for token ID {token_id} from contract {contract_address}")
+    # We need to know if it's 721 or 1155 to call the right function signature.
+    # For this placeholder, we'll just try one. A real version might try both or require type.
+    # Or, many contracts support both `tokenURI` (from 721 metadata extension) and `uri` (from 1155).
+    metadata_uri = placeholder_call_contract(contract_address, "tokenURI(uint256)", [token_id])
+    # If that failed or was empty, one might try:
+    # metadata_uri = metadata_uri or placeholder_call_contract(contract_address, "uri(uint256)", [token_id])
+    click.echo(f"Metadata URI for token {token_id}: {metadata_uri}")
+    # Add a step to fetch and display metadata if URI is http/ipfs?
+    if metadata_uri and (metadata_uri.startswith("http") or metadata_uri.startswith("ipfs")):
+        click.echo(f"To view metadata, try: ethcli nft traits --uri \"{metadata_uri}\"")
+
+
+# --- NFT Enumeration and Listing (can be complex without indexing) ---
+@nft_group.command('list721') # Previously 'list'
+@click.option('--owner', 'owner_address', required=True, help="Address of the owner/wallet to list tokens for.")
+@click.option('--contract', 'contract_address', required=True, help="Address of the ERC-721 contract.")
+# ERC721 Enumerable extension: totalSupply(), tokenByIndex(index), tokenOfOwnerByIndex(owner, index)
+def list_owned_erc721(owner_address, contract_address):
+    """List all ERC-721 tokens owned by an address for a specific contract (requires Enumerable extension support)."""
+    click.echo(f"Listing ERC-721 tokens owned by {owner_address} from contract {contract_address}")
+    click.echo("Note: This requires the contract to support the ERC721Enumerable extension.")
+    # Placeholder:
+    # 1. Call balanceOf(owner_address) to get count.
+    # 2. Loop from 0 to count-1, calling tokenOfOwnerByIndex(owner_address, index) for each.
+    balance = placeholder_call_contract(contract_address, "balanceOf(address)", [owner_address])
+    click.echo(f"Owner has {balance} tokens (simulated). Listing them:")
+    for i in range(int(balance or 0)): # Ensure balance is int
+        token_id = placeholder_call_contract(contract_address, "tokenOfOwnerByIndex(address,uint256)", [owner_address, i])
+        click.echo(f"  - Token ID: {token_id} (Simulated Index {i})")
+    if not balance or int(balance) == 0:
+        click.echo("No tokens found or enumerable extension not supported by this simulation.")
+
+
+@nft_group.command('list1155') # Previously 'list'
+@click.option('--owner', 'owner_address', required=True, help="Address of the owner/wallet.")
+@click.option('--contract', 'contract_address', required=True, help="Address of the ERC-1155 contract.")
+@click.option('--ids', 'token_ids_str', help="Comma-separated list of token IDs to check balances for (e.g., '1,2,5,10').")
+# ERC1155: balanceOfBatch(address[] owners, uint256[] ids)
+def list_balances_erc1155(owner_address, contract_address, token_ids_str):
+    """List balances of specified ERC-1155 token IDs for an owner. If no IDs, shows known ones (difficult)."""
+    click.echo(f"Listing ERC-1155 token balances for owner {owner_address} from contract {contract_address}")
+    if not token_ids_str:
+        click.echo("Please provide --ids with a comma-separated list of token IDs to check.")
+        click.echo("Listing all possible token IDs for an ERC-1155 contract without prior knowledge is generally not feasible on-chain.")
+        # To discover IDs, one might look at TransferSingle/TransferBatch events.
+        return
+
+    token_ids = [int(tid.strip()) for tid in token_ids_str.split(',')]
+    owners_list = [owner_address] * len(token_ids) # balanceOfBatch needs arrays
+
+    # Placeholder for balanceOfBatch call
+    # balances = placeholder_call_contract(contract_address, "balanceOfBatch(address[],uint256[])", [owners_list, token_ids])
+    # The above is a bit tricky for placeholder_call_contract, so we'll simulate individually:
+    click.echo(f"Balances for {owner_address} on {contract_address}:")
+    for token_id in token_ids:
+        balance = placeholder_call_contract(contract_address, "balanceOf(address,uint256)", [owner_address, token_id])
+        if int(balance or 0) > 0:
+            click.echo(f"  - Token ID {token_id}: {balance} units")
+    click.echo("(Simulated individual balanceOf calls)")
+
+
+# --- NFT Analytics and Utilities ---
+@nft_group.command('traits')
+@click.argument('metadata_uri_or_filepath', type=str) # Can be URI or local file path
+def decode_nft_traits(metadata_uri_or_filepath):
+    """Decode and show NFT traits from a metadata URI or local JSON file."""
+    click.echo(f"Decoding NFT traits from: {metadata_uri_or_filepath}")
+    metadata_content = None
+    if metadata_uri_or_filepath.startswith("http://") or metadata_uri_or_filepath.startswith("https://"):
+        click.echo("Fetching metadata from URL...")
+        # Placeholder: Use requests or similar to fetch URL
+        # metadata_content = requests.get(metadata_uri_or_filepath).json()
+        metadata_content = {"name": "Simulated NFT", "description": "Fetched from web", "image": "http://...", "attributes": [{"trait_type": "Color", "value": "Blue"}, {"trait_type": "Speed", "value": "Fast"}]}
+        click.echo("(Simulated fetch)")
+    elif metadata_uri_or_filepath.startswith("ipfs://"):
+        click.echo("Fetching metadata from IPFS URI (requires IPFS gateway or local node)...")
+        # Placeholder: Use IPFS client or public gateway
+        # ipfs_hash = metadata_uri_or_filepath.replace("ipfs://", "")
+        # metadata_content = fetch_from_ipfs_gateway(ipfs_hash)
+        metadata_content = {"name": "Simulated IPFS NFT", "description": "Fetched from IPFS", "image": "ipfs://...", "attributes": [{"trait_type": "Rarity", "value": "Legendary"}, {"trait_type": "Power", "value": "100"}]}
+        click.echo("(Simulated IPFS fetch)")
+    elif os.path.exists(metadata_uri_or_filepath):
+        click.echo("Reading metadata from local file...")
+        try:
+            with open(metadata_uri_or_filepath, 'r') as f:
+                metadata_content = json.load(f)
+        except Exception as e:
+            click.echo(f"Error reading or parsing local JSON file: {e}", err=True)
+            return
+    else:
+        click.echo("Error: Input is not a valid URL, IPFS URI, or existing file path.", err=True)
+        return
+
+    if metadata_content:
+        click.echo("--- NFT Metadata ---")
+        click.echo(f"Name: {metadata_content.get('name', 'N/A')}")
+        click.echo(f"Description: {metadata_content.get('description', 'N/A')}")
+        click.echo(f"Image URL: {metadata_content.get('image', 'N/A')}")
+
+        attributes = metadata_content.get('attributes', [])
+        if attributes:
+            click.echo("Attributes:")
+            for attr in attributes:
+                trait_type = attr.get('trait_type', 'N/A')
+                value = attr.get('value', 'N/A')
+                display_type = attr.get('display_type', None)
+                line = f"  - {trait_type}: {value}"
+                if display_type:
+                    line += f" ({display_type})"
+                click.echo(line)
+        else:
+            click.echo("No attributes found in metadata.")
+    else:
+        click.echo("Could not load or parse metadata.")
+
+
+@nft_group.command('floor')
+@click.option('--contract', 'contract_address', required=True, help="NFT Contract address to check floor price for.")
+@click.option('--marketplace', type=click.Choice(['opensea', 'looksrare', 'blur', 'auto'], case_sensitive=False), default='auto', help="Specific marketplace or auto-detect.")
+def get_floor_price(contract_address, marketplace):
+    """Estimate floor price from a known marketplace (Simulated - requires API integration)."""
+    click.echo(f"Estimating floor price for contract: {contract_address} via {marketplace} (Simulated)")
+    # Placeholder: This would require API integration with OpenSea, LooksRare, Blur, etc.
+    # These APIs often require API keys.
+    simulated_floor = "0.5 ETH" # Example
+    simulated_marketplace_name = "OpenSea (Simulated)"
+
+    click.echo(f"Simulated floor price on {simulated_marketplace_name} for {contract_address}: {simulated_floor}")
+    click.secho("Note: Real-time floor price fetching requires integration with marketplace APIs and API keys.", fg='yellow')
+
+
+@nft_group.command('history')
+@click.option('--id', 'token_id', required=True, type=int, help="Token ID to show transfer history for.")
+@click.option('--contract', 'contract_address', required=True, help="Address of the NFT contract.")
+# This requires querying past events (Transfer events for ERC721, TransferSingle/Batch for ERC1155)
+def show_token_history(token_id, contract_address):
+    """Show transfer history for a specific token ID (requires event querying)."""
+    click.echo(f"Fetching transfer history for token ID {token_id} on contract {contract_address}...")
+    click.echo("Note: This requires querying past 'Transfer' (ERC721) or 'TransferSingle'/'TransferBatch' (ERC1155) events.")
+    # Placeholder: Simulate event fetching
+    history_events = [
+        {"type": "Mint", "from": "0x000...000", "to": "0xFIRST_OWNER", "block": 12300000, "tx_hash": "0xMINT_TX_HASH..."},
+        {"type": "Transfer", "from": "0xFIRST_OWNER", "to": "0xSECOND_OWNER", "block": 12350000, "tx_hash": "0xTRANSFER_TX_HASH1..."},
+        {"type": "Transfer", "from": "0xSECOND_OWNER", "to": "0xCURRENT_OWNER", "block": 12400000, "tx_hash": "0xTRANSFER_TX_HASH2..."},
+    ]
+    click.echo("--- Transfer History (Simulated) ---")
+    for event in history_events:
+        click.echo(f"  Block: {event['block']}, Type: {event['type']}, From: {event['from']}, To: {event['to']}, Tx: {event['tx_hash']}")
+    if not history_events:
+        click.echo("No history found or event querying not fully simulated.")
+
+if __name__ == '__main__':
+    # Create dummy .sol file for testing deploy
+    # with open("DummyNFT.sol", "w") as f:
+    #    f.write("contract DummyNFT { constructor(string memory name, string memory symbol) {} }")
+    # Test: python nft_commands.py deploy721 DummyNFT.sol --name Test --symbol TST
+    # os.remove("DummyNFT.sol")
+    nft_group()

--- a/scan_commands.py
+++ b/scan_commands.py
@@ -1,0 +1,169 @@
+import click
+import subprocess # For calling external static analysis tools
+import json # For handling potential API responses
+
+# Placeholder for a function that might interact with a vulnerability database API
+def query_vulnerability_db(address):
+    """
+    Simulates querying a public vulnerability database for a given address.
+    In a real scenario, this would make an HTTP request to an API.
+    """
+    click.echo(f"Querying vulnerability database for address: {address} (Simulated)")
+    # Example: Check against a mock list of known vulnerable addresses
+    mock_vulnerable_addresses = {
+        "0xBADCONTRACT0000000000000000000000000001": ["Known Reentrancy Issue (CVE-XXXX-YYYY)", "Outdated Compiler Version"],
+        "0xANOTHERBAD0000000000000000000000000002": ["Integer Overflow Potential (SWC-101)"]
+    }
+    if address.lower() in mock_vulnerable_addresses:
+        return {"address": address, "vulnerabilities": mock_vulnerable_addresses[address.lower()], "status": "vulnerable"}
+    else:
+        # Simulate checking a contract that is not in the mock DB but might have generic checks
+        if len(address) == 42 : # Basic check if it looks like an address
+             # Simulate a case where the address is not in the DB but we can say something generic
+            return {"address": address, "vulnerabilities": [], "status": "no_known_vulnerabilities_in_db", "notes": "Address not found in our specific mock DB. This does not guarantee safety."}
+        else:
+            return {"address": address, "error": "Invalid address format."}
+
+
+@click.group('scan')
+def scan_group():
+    """Security and audit tools for smart contracts and addresses."""
+    pass
+
+@scan_group.command('audit')
+@click.argument('filepath', type=click.Path(exists=True, dir_okay=False))
+@click.option('--tool', type=click.Choice(['slither', 'mythril', 'custom'], case_sensitive=False), default='slither', help="Static analysis tool to use.")
+@click.option('--custom-command', type=str, help="Full custom command for static analysis if --tool=custom.")
+# Could add options for specific detectors, output formats, etc.
+def static_analysis_audit(filepath, tool, custom_command):
+    """
+    Run basic static analysis on a Solidity source file (.sol).
+    This often requires external tools like Slither or Mythril to be installed.
+    """
+    click.echo(f"Running static analysis audit on: {filepath} using tool: {tool}")
+
+    cmd_list = []
+    if custom_command and tool == 'custom':
+        click.echo(f"Using custom command: {custom_command}")
+        # Naive split for example; robust parsing might be needed
+        cmd_list = custom_command.split()
+    elif tool == 'slither':
+        # Assumes Slither is installed and in PATH
+        cmd_list = ["slither", filepath]
+        # Example: add common options
+        # cmd_list.extend(["--exclude-dependencies", "--json", f"{filepath}.slither.json"])
+        click.echo("Note: Slither might output a lot of information. Consider redirecting output or using specific Slither options.")
+    elif tool == 'mythril':
+        # Assumes Mythril is installed and in PATH
+        cmd_list = ["myth", "analyze", filepath]
+        # Example: myth analyze <filepath> -o json
+        click.echo("Note: Mythril analysis can take a significant amount of time.")
+    else:
+        click.echo(f"Tool '{tool}' selected, but command construction is not defined for it without --custom-command.", err=True)
+        return
+
+    if not cmd_list:
+        click.echo("No command to execute.", err=True)
+        return
+
+    click.echo(f"Executing: {' '.join(cmd_list)}")
+    try:
+        # Using shell=False is safer if cmd_list is a list of arguments
+        process = subprocess.run(cmd_list, check=True, text=True, capture_output=True)
+        click.echo(f"--- {tool.capitalize()} Output ---")
+        click.echo(process.stdout)
+        if process.stderr:
+            click.echo(f"--- {tool.capitalize()} Errors/Warnings (if any) ---", err=True)
+            click.echo(process.stderr, err=True)
+        click.echo(f"\nStatic analysis with {tool} completed.")
+    except subprocess.CalledProcessError as e:
+        click.echo(f"Error running {tool}: Command failed with exit code {e.returncode}.", err=True)
+        click.echo("Stdout:\n" + e.stdout, err=True)
+        click.echo("Stderr:\n" + e.stderr, err=True)
+    except FileNotFoundError:
+        click.echo(f"Error: The command for '{tool}' ('{cmd_list[0]}') was not found. Is it installed and in your system's PATH?", err=True)
+    except Exception as e:
+        click.echo(f"An unexpected error occurred while running {tool}: {e}", err=True)
+
+
+@scan_group.command('check')
+@click.argument('address', type=str)
+@click.option('--api-key', help="API key for the vulnerability database (if required).")
+def check_address_vulnerabilities(address, api_key):
+    """Check an address against a public database of known vulnerabilities (Simulated)."""
+    click.echo(f"Checking address {address} for known vulnerabilities...")
+    if api_key:
+        click.echo(f"Using API key: {api_key[:4]}... (if provided)")
+
+    # Placeholder: Call a function that would interact with an external API
+    result = query_vulnerability_db(address) # This is our simulated function
+
+    click.echo("--- Vulnerability Check Result (Simulated) ---")
+    click.echo(json.dumps(result, indent=2))
+
+    if result.get("status") == "vulnerable":
+        click.secho(f"Address {address} is associated with known vulnerabilities!", fg='red', bold=True)
+    elif result.get("status") == "no_known_vulnerabilities_in_db":
+        click.secho(f"No specific vulnerabilities found for {address} in the simulated database.", fg='green')
+        if result.get("notes"):
+            click.echo(f"Note: {result.get('notes')}")
+    elif result.get("error"):
+        click.secho(f"Error checking address: {result.get('error')}", fg='red')
+    else:
+        click.echo("Scan complete. Review results carefully.")
+
+
+@scan_group.command('reentrancy')
+@click.argument('address', type=str)
+@click.option('--rpc-url', help="Custom RPC URL for the test (if not using default).")
+# This is a highly specialized command. Real reentrancy testing is complex.
+# It might involve symbolic execution or specially crafted transactions.
+def test_reentrancy_risks(address, rpc_url):
+    """
+    Run a basic test for potential reentrancy risks on a deployed contract (Highly Simplified Placeholder).
+    WARNING: This is a simplified simulation. Real reentrancy detection is complex.
+    """
+    click.echo(f"Performing simplified reentrancy risk check for contract: {address}")
+    if rpc_url:
+        click.echo(f"Using RPC URL: {rpc_url}")
+    else:
+        click.echo("Using default network RPC URL (from config).")
+
+    # Placeholder: This is extremely simplified.
+    # A real tool might:
+    # 1. Fetch contract bytecode.
+    # 2. Analyze control flow graphs for patterns indicative of reentrancy (e.g., external call before state update).
+    # 3. Or, use a symbolic execution engine to try to trigger reentrant states.
+    # 4. Or, integrate with tools like Manticore, Mythril in a specific reentrancy detection mode.
+
+    click.secho("--- Reentrancy Risk Check (Simplified Placeholder) ---", fg='yellow')
+    click.echo("This is NOT a comprehensive reentrancy audit.")
+
+    # Simulate some basic checks based on hypothetical bytecode patterns or function signatures
+    # (This is pure fiction for demonstration)
+    has_fallback_payable = True # Simulated check
+    calls_before_state_update_pattern = True # Simulated check
+
+    if has_fallback_payable and calls_before_state_update_pattern:
+        click.secho(f"Potential reentrancy indicators found for {address}:", fg='yellow')
+        click.echo("  - Contract has a payable fallback/receive function (simulated).")
+        click.echo("  - Patterns suggesting external calls before state updates detected (simulated).")
+        click.secho("  Action: Manual review and thorough audit by a security expert is HIGHLY recommended.", fg='red', bold=True)
+    elif has_fallback_payable:
+        click.secho(f"Moderate reentrancy concern for {address}:", fg='yellow')
+        click.echo("  - Contract has a payable fallback/receive function (simulated).")
+        click.echo("  Action: Review usage of fallback/receive carefully.")
+    else:
+        click.secho(f"No obvious high-risk reentrancy patterns found in this simplified check for {address}.", fg='green')
+
+    click.echo("\nFor a proper audit, use specialized tools and expert review.")
+
+
+if __name__ == '__main__':
+    # Test examples:
+    # Create a dummy .sol file: echo "contract C { function f() public {} }" > dummy.sol
+    # python scan_commands.py audit dummy.sol --tool slither
+    # python scan_commands.py check 0xBADCONTRACT0000000000000000000000000001
+    # python scan_commands.py reentrancy 0xSomeContractAddress
+    # os.remove("dummy.sol") # Clean up
+    scan_group()

--- a/sign_commands.py
+++ b/sign_commands.py
@@ -1,0 +1,115 @@
+import click
+import json # For typed data
+
+# Assume a way to get the current active wallet's address and signing capabilities
+def get_active_signer():
+    # Placeholder: In a real app, this would fetch from wallet manager
+    # and return an object that can sign messages/transactions
+    class MockSigner:
+        def __init__(self, address):
+            self.address = address
+
+        def sign_message(self, message_bytes):
+            # Placeholder for actual signing
+            return f"0xSIGNED{message_bytes.hex()}BY{self.address}"
+
+        def sign_typed_data(self, typed_data_dict):
+            # Placeholder for actual EIP-712 signing
+            return f"0xSIGNED{json.dumps(typed_data_dict)}BY{self.address}"
+
+    return MockSigner("0xACTIVEWALLETADDRESSFORSIGNING00000")
+
+
+@click.group('sign')
+def sign_group():
+    """Sign and verify messages and transactions using the active wallet."""
+    pass
+
+@sign_group.command('msg')
+@click.argument('message', type=str)
+def sign_message(message):
+    """Sign a plain text message (EIP-191 personal_sign)."""
+    signer = get_active_signer()
+    click.echo(f"Signing message from address: {signer.address}")
+    click.echo(f"Message: \"{message}\"")
+
+    # Placeholder: Implement EIP-191 message signing
+    # Usually involves prefixing "\x19Ethereum Signed Message:\n" + len(message) + message
+    # and then signing the keccak256 hash of that.
+    # message_bytes = message.encode('utf-8')
+    # signature = signer.sign_message(message_bytes) # This needs to be the actual web3.py personal.sign or equivalent
+
+    # Example using a mock signer for structure
+    # In web3.py, this would be like:
+    # from eth_account.messages import encode_defunct
+    # message_hash = encode_defunct(text=message)
+    # signed_message = web3.eth.account.sign_message(message_hash, private_key=...)
+    # signature = signed_message.signature.hex()
+
+    signature_hex = f"0xMOCKS IGNATUREOFMESSAGE_{signer.address}" # Placeholder
+    click.echo(f"Signature: {signature_hex}")
+
+@sign_group.command('typed')
+@click.argument('json_data', type=str) # Expects a JSON string for EIP-712
+def sign_typed_data(json_data):
+    """Sign EIP-712 typed data provided as a JSON string."""
+    signer = get_active_signer()
+    click.echo(f"Signing typed data from address: {signer.address}")
+
+    try:
+        typed_data_dict = json.loads(json_data)
+        click.echo("Typed Data (JSON):")
+        click.echo(json.dumps(typed_data_dict, indent=2))
+    except json.JSONDecodeError as e:
+        click.echo(f"Error: Invalid JSON provided for typed data. {e}", err=True)
+        return
+
+    # Placeholder: Implement EIP-712 signing
+    # from eth_account.messages import encode_structured_data
+    # signable_message = encode_structured_data(primitive=typed_data_dict) # or text=json_data
+    # signed_message = web3.eth.account.sign_message(signable_message, private_key=...)
+    # signature = signed_message.signature.hex()
+
+    signature_hex = f"0xMOCKS IGNATUREOFTYPEDDATA_{signer.address}" # Placeholder
+    click.echo(f"Signature: {signature_hex}")
+
+@sign_group.command('verify')
+@click.argument('message', type=str)
+@click.option('--sig', 'signature_hex', required=True, type=str, help="The signature (hex string) to verify.")
+@click.option('--address', 'signer_address', type=str, help="The alleged signer's address (optional, otherwise tries to recover).")
+@click.option('--is-typed', is_flag=True, help="Indicates the message is EIP-712 JSON, not plain text.")
+def verify_signature(message, signature_hex, signer_address, is_typed):
+    """Verify a signed message (plain or EIP-712 typed)."""
+    click.echo(f"Verifying signature: {signature_hex}")
+    if is_typed:
+        click.echo(f"For EIP-712 typed data: {message[:50]}...")
+        try:
+            typed_data_dict = json.loads(message)
+            # In a real scenario:
+            # from eth_account.messages import encode_structured_data
+            # message_hash = encode_structured_data(primitive=typed_data_dict)
+        except json.JSONDecodeError as e:
+            click.echo(f"Error: Invalid JSON provided for typed data. {e}", err=True)
+            return
+    else:
+        click.echo(f"For plain message: \"{message}\"")
+        # In a real scenario:
+        # from eth_account.messages import encode_defunct
+        # message_hash = encode_defunct(text=message)
+
+    # Placeholder: Implement signature recovery and verification
+    # recovered_address = web3.eth.account.recover_message(message_hash, signature=signature_hex)
+
+    recovered_address_example = "0xRECOVEREDADDRESSFROMTHEMESSAGEANDSIG" # Placeholder
+
+    if signer_address:
+        click.echo(f"Alleged signer: {signer_address}")
+        if recovered_address_example.lower() == signer_address.lower():
+            click.echo(click.style(f"Signature is VALID. Recovered address {recovered_address_example} matches provided address.", fg='green'))
+        else:
+            click.echo(click.style(f"Signature is INVALID. Recovered address {recovered_address_example} does not match provided address.", fg='red'))
+    else:
+        click.echo(click.style(f"Signature is VALID (assuming correct message format). Recovered address: {recovered_address_example}", fg='green'))
+
+if __name__ == '__main__':
+    sign_group()

--- a/sync_commands.py
+++ b/sync_commands.py
@@ -1,0 +1,116 @@
+import click
+import json # For structured output
+
+@click.group('sync')
+def sync_group():
+    """Node and state sync utilities (primarily for local node operators)."""
+    pass
+
+@sync_group.command('status')
+# Assumes interaction with a local Ethereum node client (e.g., Geth, Nethermind)
+def sync_status():
+    """Show sync status of the connected/local Ethereum node."""
+    click.echo("Fetching sync status from local Ethereum node...")
+
+    # Placeholder: Implement logic to call appropriate RPC methods
+    # For example, web3.eth.syncing or net_syncing (depending on client)
+    # Example response structure if syncing:
+    # {
+    #   "startingBlock": "0x123",
+    #   "currentBlock": "0x456",
+    #   "highestBlock": "0x789",
+    #   "knownStates": "0xabc",
+    #   "pulledStates": "0xdef"
+    # }
+    # If not syncing, the result is often `False`.
+
+    syncing_data_example = {
+        "status": "Syncing",
+        "currentBlock": 15000100,
+        "highestBlock": 15000500,
+        "progressPercent": "99.97%"
+    }
+    # Or if fully synced:
+    # syncing_data_example = {"status": "Fully Synced", "currentBlock": 15000500}
+
+    click.echo(json.dumps(syncing_data_example, indent=2))
+    if syncing_data_example.get("status") == "Syncing":
+        click.echo("Node is currently syncing.")
+    else:
+        click.echo("Node appears to be fully synced or not actively syncing.")
+
+@sync_group.command('peers')
+@click.option('--details', is_flag=True, help="Show detailed information for each peer.")
+def list_peers(details):
+    """Show connected peers of the local Ethereum node."""
+    click.echo("Fetching list of connected peers...")
+
+    # Placeholder: Implement logic to call `admin_peers` or `net_peerCount` / `net_peers`
+    # Example `admin_peers` output structure is complex, often includes:
+    # id, name, caps, network (localAddress, remoteAddress), protocols
+
+    if details:
+        peers_data_example = [
+            {
+                "id": "peer_id_1_very_long_hex_string...",
+                "name": "Geth/v1.10.25-stable-c5631695/linux-amd64/go1.19.3",
+                "caps": ["eth/66", "eth/67"],
+                "network": {
+                    "localAddress": "192.168.1.10:30303",
+                    "remoteAddress": "1.2.3.4:30303",
+                    "inbound": False,
+                    "static": False,
+                    "trusted": False
+                },
+                "protocols": {"eth": {"version": 67, "difficulty": "...", "head": "..."}}
+            },
+            # ... more peers
+        ]
+        click.echo(json.dumps(peers_data_example, indent=2))
+        click.echo(f"Total peers: {len(peers_data_example)} (Placeholder with details)")
+    else:
+        # Placeholder for `net_peerCount`
+        peer_count_example = 25
+        click.echo(f"Connected peers: {peer_count_example} (Placeholder summary)")
+        click.echo("Use --details for more information on each peer.")
+
+
+@sync_group.command('rebuild')
+@click.confirmation_option(prompt="Are you sure you want to trigger a node resync/reindex? This can take a very long time.")
+# This command is highly dependent on the specific node client and its capabilities.
+# Some nodes might not support this via RPC, or require specific startup flags.
+def force_rebuild():
+    """
+    Attempt to force a resync or reindex of the local node.
+    WARNING: This is a potentially disruptive operation.
+    Actual capability depends on the connected Ethereum node client.
+    """
+    click.echo("Attempting to trigger node resync/reindex...")
+    # Placeholder: This is very client-specific.
+    # Geth: Might involve `debug_setHead` to an old block, or more drastically, stopping the node,
+    #       deleting chaindata (NOT recommended via CLI tool), and restarting.
+    # Nethermind: Might have specific diagnostic commands.
+    # Erigon: Similar considerations.
+    click.secho("This command is a placeholder. Actual implementation requires specific node client interaction, "
+                "which might not be safe or feasible via a generic CLI RPC call.", fg='yellow')
+    click.echo("Typically, this involves manual node operations like stopping the node, removing the database, and restarting.")
+    click.echo("If your node client supports a specific RPC for this, it would be called here.")
+
+@sync_group.command('snapshot')
+# This is also very node-client specific. Not all clients support snapshot creation via RPC.
+def export_snapshot():
+    """
+    Export a node snapshot if the connected node client supports it.
+    Capability and method depend on the Ethereum node client.
+    """
+    click.echo("Attempting to export node snapshot...")
+    # Placeholder: Client-specific logic.
+    # Geth: Snapshots are part of its sync process; direct export via RPC is not standard.
+    #       `debug_chaindbProperty("snapshot")` might give info.
+    # Some clients might have specific commands or export mechanisms.
+    click.secho("This command is a placeholder. Snapshot export functionality is highly client-dependent "
+                "and often managed through the node's own CLI or configuration, not generic RPCs.", fg='yellow')
+    click.echo("If your node client supports an RPC for snapshot creation/export, it would be invoked here.")
+
+if __name__ == '__main__':
+    sync_group()

--- a/test_commands.py
+++ b/test_commands.py
@@ -1,0 +1,186 @@
+import click
+import subprocess # For running external test runners
+import os
+
+@click.group('test')
+def test_group():
+    """Run contract tests locally, often using a development framework."""
+    pass
+
+@test_group.command('run')
+@click.argument('test_file_or_dir', type=click.Path(exists=True), required=False)
+@click.option('--framework', type=click.Choice(['hardhat', 'foundry', 'truffle', 'custom'], case_sensitive=False),
+              help="Specify the testing framework. If 'custom', provide full command with --custom-command.")
+@click.option('--custom-command', type=str, help="Full custom command to run tests (e.g., 'npm run test:specific').")
+# We could add options like --grep to filter tests by name
+def run_tests(test_file_or_dir, framework, custom_command):
+    """
+    Run test script(s). Detects common frameworks or uses a custom command.
+    If TEST_FILE_OR_DIR is provided, it will be passed to the test runner if supported.
+    """
+    if custom_command:
+        click.echo(f"Running custom test command: {custom_command}")
+        # It's good practice to split the command string into a list for subprocess
+        # For simplicity here, we assume it's well-formed or the user knows what they're doing.
+        # A more robust solution would parse it carefully.
+        try:
+            process = subprocess.run(custom_command, shell=True, check=True, text=True, capture_output=True)
+            click.echo("Custom command output:\n" + process.stdout)
+            if process.stderr:
+                click.echo("Custom command errors:\n" + process.stderr, err=True)
+            click.echo("Custom command executed successfully.")
+        except subprocess.CalledProcessError as e:
+            click.echo(f"Custom command failed with exit code {e.returncode}.", err=True)
+            click.echo("Output:\n" + e.stdout, err=True)
+            click.echo("Errors:\n" + e.stderr, err=True)
+        except FileNotFoundError:
+            click.echo(f"Error: Custom command not found. Make sure it's in your PATH or a valid script.", err=True)
+        return
+
+    detected_framework = framework
+    if not detected_framework:
+        # Basic framework detection
+        if os.path.exists("hardhat.config.js") or os.path.exists("hardhat.config.ts"):
+            detected_framework = "hardhat"
+        elif os.path.exists("foundry.toml"):
+            detected_framework = "foundry"
+        elif os.path.exists("truffle-config.js"):
+            detected_framework = "truffle"
+        else:
+            click.echo("Could not automatically detect testing framework (Hardhat, Foundry, Truffle).")
+            click.echo("Please specify with --framework or use --custom-command.", err=True)
+            return
+
+    click.echo(f"Using testing framework: {detected_framework}")
+    cmd = []
+    if detected_framework == "hardhat":
+        cmd = ["npx", "hardhat", "test"]
+        if test_file_or_dir:
+            cmd.append(test_file_or_dir)
+    elif detected_framework == "foundry":
+        cmd = ["forge", "test"]
+        if test_file_or_dir: # Foundry test might take specific options for file/contract/test function
+            click.echo(f"Note: For Foundry, targeting specific files/tests usually involves options like --match-path, --match-contract, --match-test.")
+            click.echo(f"Passing '{test_file_or_dir}' directly might not work as expected without specific matching options.")
+            # cmd.extend(["--match-path", test_file_or_dir]) # Example, needs refinement
+    elif detected_framework == "truffle":
+        cmd = ["npx", "truffle", "test"]
+        if test_file_or_dir:
+            cmd.append(test_file_or_dir)
+
+    if not cmd:
+        click.echo(f"Framework {detected_framework} is chosen, but automatic command construction is not fully implemented yet.", err=True)
+        return
+
+    click.echo(f"Executing command: {' '.join(cmd)}")
+    try:
+        # Using shell=False is generally safer if cmd is a list
+        process = subprocess.run(cmd, check=True, text=True, capture_output=True) # Use capture_output to get stdout/stderr
+        click.echo("Test run output:\n" + process.stdout)
+        if process.stderr:
+             click.echo("Test run errors (if any):\n" + process.stderr, err=True) # Some tools output to stderr even on success
+        click.echo(f"{detected_framework.capitalize()} tests completed successfully.")
+    except subprocess.CalledProcessError as e:
+        click.echo(f"{detected_framework.capitalize()} tests failed with exit code {e.returncode}.", err=True)
+        click.echo("Output:\n" + e.stdout, err=True)
+        click.echo("Errors:\n" + e.stderr, err=True)
+    except FileNotFoundError:
+        click.echo(f"Error: Command for {detected_framework} not found. Is it installed and in your PATH?", err=True)
+    except Exception as e:
+        click.echo(f"An unexpected error occurred: {e}", err=True)
+
+
+@test_group.command('coverage')
+@click.option('--framework', type=click.Choice(['hardhat', 'foundry', 'custom'], case_sensitive=False),
+              help="Specify the testing framework. If 'custom', provide full command with --custom-command.")
+@click.option('--custom-command', type=str, help="Full custom command to run coverage (e.g., 'npm run coverage').")
+def show_coverage(framework, custom_command):
+    """Show test coverage (requires framework support, e.g., solidity-coverage for Hardhat)."""
+    if custom_command:
+        click.echo(f"Running custom coverage command: {custom_command}")
+        try:
+            subprocess.run(custom_command, shell=True, check=True)
+            click.echo("Custom coverage command executed successfully.")
+        except subprocess.CalledProcessError as e:
+            click.echo(f"Custom coverage command failed with exit code {e.returncode}.", err=True)
+        except FileNotFoundError:
+            click.echo(f"Error: Custom command not found.", err=True)
+        return
+
+    detected_framework = framework
+    if not detected_framework:
+        if os.path.exists("hardhat.config.js") or os.path.exists("hardhat.config.ts"):
+            detected_framework = "hardhat"
+        elif os.path.exists("foundry.toml"):
+            detected_framework = "foundry"
+        else:
+            click.echo("Could not automatically detect framework for coverage (Hardhat, Foundry).")
+            click.echo("Please specify with --framework or use --custom-command.", err=True)
+            return
+
+    click.echo(f"Attempting to run coverage for framework: {detected_framework}")
+    cmd = []
+    if detected_framework == "hardhat":
+        # Assumes solidity-coverage is installed and configured
+        cmd = ["npx", "hardhat", "coverage"]
+    elif detected_framework == "foundry":
+        cmd = ["forge", "coverage"]
+        # May need additional options like --report lcov or --report summary
+
+    if not cmd:
+        click.echo(f"Coverage for {detected_framework} is chosen, but automatic command construction is not fully implemented.", err=True)
+        return
+
+    click.echo(f"Executing command: {' '.join(cmd)}")
+    try:
+        subprocess.run(cmd, check=True)
+        click.echo(f"{detected_framework.capitalize()} coverage report generated.")
+        if detected_framework == "hardhat":
+            click.echo("Coverage report typically found in ./coverage/index.html or terminal output.")
+        elif detected_framework == "foundry":
+            click.echo("Coverage report typically found in ./coverage/ or terminal output. Use 'forge coverage --report summary' for quick view.")
+    except subprocess.CalledProcessError as e:
+        click.echo(f"{detected_framework.capitalize()} coverage command failed.", err=True)
+    except FileNotFoundError:
+        click.echo(f"Error: Command for {detected_framework} coverage not found. Is it installed and configured (e.g., solidity-coverage for Hardhat)?", err=True)
+    except Exception as e:
+        click.echo(f"An unexpected error occurred during coverage: {e}", err=True)
+
+
+@test_group.command('fork')
+@click.argument('network_to_fork', type=str, default="mainnet") # e.g., mainnet, goerli, or a custom RPC URL
+@click.option('--block-number', type=int, help="Fork from a specific block number.")
+@click.option('--port', type=int, default=8545, help="Port for the local forked node.")
+# This command would typically start a local node (Anvil/Hardhat Node) configured to fork a live network.
+# Then, subsequent `ethcli test run` or other commands would target this local forked node.
+def run_on_fork(network_to_fork, block_number, port):
+    """Run tests on a mainnet (or other network) fork. (Starts a local forked node)."""
+    click.echo(f"Preparing to start a local forked node from: {network_to_fork}")
+    if block_number:
+        click.echo(f"Forking from block number: {block_number}")
+    click.echo(f"Local node will run on port: {port}")
+
+    # Placeholder: This requires starting a local node like Anvil or Hardhat Node
+    # with appropriate forking configuration.
+
+    # Example for Anvil (Foundry):
+    # cmd_anvil = ["anvil", "--fork-url", network_to_fork_rpc_url, "--port", str(port)]
+    # if block_number: cmd_anvil.extend(["--fork-block-number", str(block_number)])
+
+    # Example for Hardhat Node:
+    # This is usually configured in hardhat.config.js and run via `npx hardhat node`
+    # Or can be started programmatically, but that's more involved.
+
+    click.secho("This command is a placeholder for starting a local forked development node.", fg='yellow')
+    click.echo("You would typically use a tool like Anvil (Foundry) or Hardhat Node.")
+    click.echo("Example (Anvil):")
+    rpc_url = f"https://{network_to_fork}.infura.io/v3/YOUR_INFURA_ID" if not network_to_fork.startswith("http") else network_to_fork
+    anvil_cmd_parts = ["anvil", "--fork-url", rpc_url, "--port", str(port)]
+    if block_number:
+        anvil_cmd_parts.extend(["--fork-block-number", str(block_number)])
+    click.echo(f"  {' '.join(anvil_cmd_parts)}")
+    click.echo("\nOnce the forked node is running, configure ethcli to use it (e.g., `ethcli network use local_fork`)")
+    click.echo("and then run your tests: `ethcli test run` (ensure your tests are configured for this network).")
+
+if __name__ == '__main__':
+    test_group()

--- a/tx_commands.py
+++ b/tx_commands.py
@@ -1,0 +1,69 @@
+import click
+
+@click.group('tx')
+def tx_group():
+    """Create and send Ethereum transactions."""
+    pass
+
+@tx_group.command('send')
+@click.option('--to', 'to_address', required=True, type=str, help="Recipient Ethereum address.")
+@click.option('--value', required=True, type=str, help="Amount of ETH to send (e.g., 0.5eth, 100gwei, 1000000000000000000wei).")
+# We could add options for gas price, gas limit, nonce, data later
+def send_transaction(to_address, value):
+    """Send ETH to an address."""
+    click.echo(f"Preparing to send {value} to address: {to_address}")
+    # Placeholder: Implement transaction creation and sending logic
+    # This would involve:
+    # 1. Validating the 'value' format (eth, gwei, wei) and converting to wei.
+    # 2. Getting the current wallet's address.
+    # 3. Fetching nonce.
+    # 4. Estimating gas.
+    # 5. Building the transaction object.
+    # 6. Signing the transaction.
+    # 7. Sending the raw transaction.
+    click.echo(f"Transaction submitted. Hash: 0xTRANSACTIONHASH...")
+
+@tx_group.command('status')
+@click.argument('txhash', type=str)
+def transaction_status(txhash):
+    """Check status of a transaction."""
+    click.echo(f"Checking status for transaction: {txhash}")
+    # Placeholder: Implement transaction status checking logic
+    click.echo(f"Status for {txhash}: Confirmed (Block #123456)")
+    click.echo(f"From: 0xSENDER, To: 0xRECIPIENT, Value: X ETH")
+
+@tx_group.command('gas-estimate')
+@click.option('--to', 'to_address', required=True, type=str, help="Recipient address for gas estimation.")
+@click.option('--value', type=str, help="Value in ETH, Gwei, or Wei (optional).")
+@click.option('--data', 'tx_data', type=str, help="Transaction data (hex string, optional).")
+def gas_estimate(to_address, value, tx_data):
+    """Estimate gas for a transaction."""
+    click.echo(f"Estimating gas for a transaction to: {to_address}")
+    if value:
+        click.echo(f"Value: {value}")
+    if tx_data:
+        click.echo(f"Data: {tx_data[:10]}... (if long)")
+    # Placeholder: Implement gas estimation logic
+    estimated_gas = 21000  # Example for a simple ETH transfer
+    if tx_data:
+        estimated_gas += 50000 # Rough addition for contract interaction
+    click.echo(f"Estimated Gas: {estimated_gas} units")
+
+@tx_group.command('simulate')
+@click.option('--to', 'to_address', required=True, type=str, help="Recipient address for simulation.")
+@click.option('--value', type=str, default="0eth", help="Value in ETH, Gwei, or Wei (e.g., 0.1eth).")
+@click.option('--data', 'tx_data', type=str, help="Transaction data (hex string, optional for contract calls).")
+# Could also take --from <address> if we want to simulate from a different account than the active wallet
+def simulate_transaction(to_address, value, tx_data):
+    """Simulate a transaction to predict outcome (e.g., revert reasons)."""
+    click.echo(f"Simulating transaction:")
+    click.echo(f"  To: {to_address}")
+    click.echo(f"  Value: {value}")
+    if tx_data:
+        click.echo(f"  Data: {tx_data[:20]}...")
+    # Placeholder: Implement transaction simulation logic (e.g., using eth_call)
+    click.echo("Simulation successful. No revert detected.")
+    # Or: click.echo("Simulation failed. Revert reason: 'ERC20: transfer amount exceeds balance'")
+
+if __name__ == '__main__':
+    tx_group()

--- a/wallet_commands.py
+++ b/wallet_commands.py
@@ -1,0 +1,77 @@
+import click
+
+@click.group('wallet')
+def wallet_group():
+    """Create, import, export, and manage Ethereum wallets."""
+    pass
+
+@wallet_group.command('create')
+@click.option('--name', 'alias', type=str, help="Alias for the new wallet.")
+def create_wallet(alias):
+    """Generate a new wallet."""
+    if alias:
+        click.echo(f"Generating a new wallet with alias: {alias}...")
+    else:
+        click.echo("Generating a new wallet...")
+    # Placeholder: Implement actual wallet generation logic
+    click.echo("Wallet created successfully. Mnemonic: ... Private Key: ... Address: ...")
+
+@wallet_group.command('import')
+@click.option('--private-key', 'private_key_hex', type=str, help="Import using private key (hex).")
+@click.option('--mnemonic', 'mnemonic_phrase', type=str, help="Import using mnemonic phrase.")
+def import_wallet(private_key_hex, mnemonic_phrase):
+    """Import a wallet using a private key or mnemonic phrase."""
+    if private_key_hex:
+        click.echo(f"Importing wallet using private key: {private_key_hex[:4]}...{private_key_hex[-4:]}")
+        # Placeholder: Implement private key import logic
+    elif mnemonic_phrase:
+        click.echo(f"Importing wallet using mnemonic: \"{mnemonic_phrase.split(' ')[0]} ... {mnemonic_phrase.split(' ')[-1]}\"")
+        # Placeholder: Implement mnemonic import logic
+    else:
+        click.echo("Please provide either --private-key or --mnemonic to import a wallet.", err=True)
+        # It might be better to make these options mutually exclusive and one of them required
+        # For now, this provides a basic check.
+        return
+    click.echo("Wallet imported successfully.")
+
+@wallet_group.command('list')
+def list_wallets():
+    """Show stored wallets."""
+    click.echo("Listing stored wallets...")
+    # Placeholder: Implement wallet listing logic
+    click.echo("- mywallet1 (0xabc...def)")
+    click.echo("- mywallet2 (0x123...789)")
+
+@wallet_group.command('select')
+@click.argument('alias', type=str)
+def select_wallet(alias):
+    """Set active wallet."""
+    click.echo(f"Setting active wallet to: {alias}")
+    # Placeholder: Implement active wallet selection logic
+
+@wallet_group.command('export')
+@click.argument('alias', type=str)
+@click.option('--show-private', is_flag=True, help="Show private key (use with caution).")
+def export_wallet(alias, show_private):
+    """Export wallet info (address, optionally private key)."""
+    click.echo(f"Exporting wallet information for: {alias}")
+    # Placeholder: Implement wallet export logic
+    click.echo(f"Address: 0x123...abc (for {alias})")
+    if show_private:
+        click.secho("WARNING: Displaying private key. Handle with extreme care!", fg='yellow', bold=True)
+        click.echo(f"Private Key: 0xPRIVATEKEYHEX... (for {alias})")
+    else:
+        click.echo("Private key hidden. Use --show-private to display it.")
+
+@wallet_group.command('delete')
+@click.argument('alias', type=str)
+def delete_wallet(alias):
+    """Delete a wallet."""
+    # It's good practice to ask for confirmation for destructive actions.
+    if click.confirm(f"Are you sure you want to delete wallet '{alias}'? This action cannot be undone.", abort=True):
+        click.echo(f"Deleting wallet: {alias}")
+        # Placeholder: Implement wallet deletion logic
+        click.echo(f"Wallet '{alias}' deleted successfully.")
+
+if __name__ == '__main__':
+    wallet_group()


### PR DESCRIPTION
This commit introduces the foundational Python CLI structure for the Ethereum CLI tool.

Key changes:
- Created a main `cli.py` using the `click` library to orchestrate command groups.
- Implemented 15 distinct command group modules, each in its own file:
    - `network_commands.py`
    - `wallet_commands.py`
    - `tx_commands.py`
    - `contract_commands.py`
    - `compile_commands.py`
    - `account_commands.py`
    - `analytics_commands.py`
    - `sign_commands.py`
    - `sync_commands.py`
    - `test_commands.py`
    - `config_commands.py`
    - `help_commands.py` (includes a custom `examples` subcommand)
    - `export_commands.py`
    - `scan_commands.py`
    - `nft_commands.py`
- Each module defines its respective subcommands using `click` decorators (`@click.group`, `@click.command`).
- All actual blockchain interaction logic and complex functionalities are currently implemented as placeholders (e.g., `click.echo("Simulating...")` or mock functions).
- The focus of this commit is on establishing the overall CLI argument parsing structure, help messages, and file organization as per the initial plan.

The next steps would involve adding `click` to dependencies, thoroughly testing the CLI structure, and then incrementally implementing the actual logic for each command.