### PR TITLE
feat: Implement Ethereum CLI tool

### DIFF
--- a/account_commands.py
+++ b/account_commands.py
@@ -1,75 +1,64 @@
-import click
+from web3 import Web3
+from decimal import Decimal
 
-# Assume a way to get the current active wallet's address
-def get_active_wallet_address():
-    # Placeholder: In a real app, this would fetch from config or state
-    return "0xACTIV WALLETADDRESSDEFAULT00000000000"
+def get_web3_instance(node_url):
+    """Initializes and returns a Web3 instance connected to the given node URL."""
+    return Web3(Web3.HTTPProvider(node_url))
 
-@click.group('account')
-def account_group():
-    """Show wallet balances, nonce, tokens, and resolve ENS names."""
-    pass
+def wei_to_ether(wei_balance):
+    """Converts a balance from Wei to Ether."""
+    return Decimal(wei_balance) / Decimal(10**18)
 
-@account_group.command('balance')
-@click.option('--address', 'target_address', type=str, help="Address to check balance for (defaults to active wallet).")
-@click.option('--token', 'token_contract_address', type=str, help="ERC-20 token contract address (optional).")
-@click.option('--block', 'block_identifier', type=str, help="Block number or tag (e.g., 'latest', 'pending', or a number) (optional).")
-def get_balance(target_address, token_contract_address, block_identifier):
-    """Show ETH or token balance for an address."""
-    address_to_check = target_address or get_active_wallet_address()
-    block_info = f" at block {block_identifier}" if block_identifier else ""
+def get_balance(args, node_url, default_address):
+    """Fetches and displays the ETH balance of an Ethereum address."""
+    address = args.address if hasattr(args, 'address') and args.address else default_address
+    if not address:
+        print("Error: No address specified or cached. Use 'set_address' or provide an address.")
+        return
 
-    if token_contract_address:
-        click.echo(f"Fetching ERC-20 token balance for token {token_contract_address} at address {address_to_check}{block_info}...")
-        # Placeholder: Implement ERC-20 token balance fetching
-        # 1. Need ABI for ERC-20 (balanceOf function).
-        # 2. Call balanceOf(address_to_check) on the token_contract_address.
-        # 3. Format the result (considering token decimals).
-        click.echo(f"Token Balance (Token: {token_contract_address}): 123.45 TKN (Example)")
-    else:
-        click.echo(f"Fetching ETH balance for address: {address_to_check}{block_info}...")
-        # Placeholder: Implement ETH balance fetching (web3.eth.get_balance)
-        click.echo(f"ETH Balance: 1.2345 ETH (Example)")
+    try:
+        w3 = get_web3_instance(node_url)
+        if not w3.is_connected():
+            print(f"Error: Could not connect to Ethereum node at {node_url}")
+            return
 
-@account_group.command('nonce')
-@click.option('--address', 'target_address', type=str, help="Address to check nonce for (defaults to active wallet).")
-@click.option('--block', 'block_identifier', type=str, default='pending', help="Block number or tag (e.g., 'latest', 'pending') (defaults to 'pending').")
-def get_nonce(target_address, block_identifier):
-    """Show current nonce for an address."""
-    address_to_check = target_address or get_active_wallet_address()
-    click.echo(f"Fetching nonce for address: {address_to_check} at block: {block_identifier}...")
-    # Placeholder: Implement nonce fetching (web3.eth.get_transaction_count)
-    click.echo(f"Nonce: 42 (Example)")
+        checksum_address = Web3.to_checksum_address(address)
+        balance_wei = w3.eth.get_balance(checksum_address)
+        balance_eth = wei_to_ether(balance_wei)
+        print(f"Balance for {checksum_address}: {balance_eth:.18f} ETH")
+    except Exception as e:
+        print(f"Error fetching balance for {address}: {e}")
 
-@account_group.command('tokens')
-@click.option('--address', 'target_address', type=str, help="Address to list tokens for (defaults to active wallet).")
-# Could add --min-balance to filter small balances
-def list_tokens(target_address):
-    """List ERC-20 tokens held by an address."""
-    address_to_check = target_address or get_active_wallet_address()
-    click.echo(f"Listing ERC-20 tokens for address: {address_to_check}...")
-    # Placeholder: Implement token listing. This is complex and might involve:
-    # 1. Querying a token list service (e.g., Uniswap's list, CoinGecko).
-    # 2. Or, scanning transaction history for 'Transfer' events to this address.
-    # 3. Or, using a service like Etherscan API or Covalent/Alchemy/Infura token APIs.
-    click.echo("  Token: DAI (0x6B175474E89094C44Da98b954EedeAC495271d0F), Balance: 100.0")
-    click.echo("  Token: USDC (0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48), Balance: 50.5")
-    click.echo("(Placeholder - requires external data source or indexing)")
+def get_transaction_count(args, node_url, default_address):
+    """Fetches and displays the transaction count (nonce) of an Ethereum address."""
+    address = args.address if hasattr(args, 'address') and args.address else default_address
+    if not address:
+        print("Error: No address specified or cached. Use 'set_address' or provide an address.")
+        return
 
-@account_group.command('ens')
-@click.argument('name_or_address', type=str)
-def resolve_ens(name_or_address):
-    """Resolve ENS name to address, or perform reverse lookup for an address."""
-    if name_or_address.startswith('0x'):
-        click.echo(f"Performing reverse ENS lookup for address: {name_or_address}...")
-        # Placeholder: Implement ENS reverse lookup (web3.ens.name(address))
-        click.echo(f"ENS Name: vitalik.eth (Example)")
-    elif '.eth' in name_or_address:
-        click.echo(f"Resolving ENS name: {name_or_address}...")
-        # Placeholder: Implement ENS name resolution (web3.ens.address(name))
-        click.echo(f"Address: 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045 (Example for vitalik.eth)")
-    else:
-        click.echo("Invalid input. Please provide an ENS name (e.g., 'vitalik.eth') or an Ethereum address (e.g., '0x...').", err=True)
+    try:
+        w3 = get_web3_instance(node_url)
+        if not w3.is_connected():
+            print(f"Error: Could not connect to Ethereum node at {node_url}")
+            return
 
-if __name__ == '__main__':
-    account_group()
+        checksum_address = Web3.to_checksum_address(address)
+        nonce = w3.eth.get_transaction_count(checksum_address)
+        print(f"Transaction count for {checksum_address}: {nonce}")
+    except Exception as e:
+        print(f"Error fetching transaction count for {address}: {e}")
+
+def register_account_commands(subparsers):
+    """Registers account-related subcommands to the main parser."""
+    account_parser = subparsers.add_parser("account", help="Commands for Ethereum accounts")
+    account_subparsers = account_parser.add_subparsers(title="account_commands", dest="account_command", required=True)
+
+    # Get balance command
+    balance_parser = account_subparsers.add_parser("balance", help="Get ETH balance for an address.")
+    balance_parser.add_argument("address", nargs="?", help="Ethereum address (e.g., 0x...). Uses cached address if not provided.")
+    balance_parser.set_defaults(func=get_balance)
+
+    # Get transaction count command
+    tx_count_parser = account_subparsers.add_parser("tx_count", help="Get transaction count (nonce) for an address.")
+    tx_count_parser.add_argument("address", nargs="?", help="Ethereum address (e.g., 0x...). Uses cached address if not provided.")
+    tx_count_parser.set_defaults(func=get_transaction_count)

--- a/eth_cli.py
+++ b/eth_cli.py
@@ -1,0 +1,105 @@
+import argparse
+import os
+import sys
+
+from account_commands import register_account_commands
+from network_commands import register_network_commands
+
+# Location to cache the Ethereum address
+ADDRESS_CACHE_FILE = os.path.expanduser("~/.eth_cli_address")
+NODE_URL_CACHE_FILE = os.path.expanduser("~/.eth_cli_node_url")
+
+def set_address(args):
+    """Saves the Ethereum address to the cache file."""
+    with open(ADDRESS_CACHE_FILE, "w") as f:
+        f.write(args.address)
+    print(f"Ethereum address {args.address} saved.")
+
+def get_cached_address():
+    """Retrieves the cached Ethereum address."""
+    if os.path.exists(ADDRESS_CACHE_FILE):
+        with open(ADDRESS_CACHE_FILE, "r") as f:
+            return f.read().strip()
+    return None
+
+def set_node_url(args):
+    """Saves the Ethereum node URL to the cache file."""
+    with open(NODE_URL_CACHE_FILE, "w") as f:
+        f.write(args.url)
+    print(f"Ethereum node URL {args.url} saved.")
+
+def get_cached_node_url():
+    """Retrieves the cached Ethereum node URL."""
+    if os.path.exists(NODE_URL_CACHE_FILE):
+        with open(NODE_URL_CACHE_FILE, "r") as f:
+            return f.read().strip()
+    return None
+
+def main():
+    parser = argparse.ArgumentParser(description="A CLI tool to interact with the Ethereum blockchain.")
+    subparsers = parser.add_subparsers(title="commands", dest="command", required=True)
+
+    # Top-level command for setting the address
+    set_address_parser = subparsers.add_parser("set_address", help="Save your Ethereum address.")
+    set_address_parser.add_argument("address", help="Your Ethereum address (e.g., 0x...)")
+    set_address_parser.set_defaults(func=set_address)
+
+    # Top-level command for setting the node URL
+    set_node_url_parser = subparsers.add_parser("set_node_url", help="Save your Ethereum node URL (e.g., Infura/Alchemy HTTP endpoint).")
+    set_node_url_parser.add_argument("url", help="Ethereum node URL")
+    set_node_url_parser.set_defaults(func=set_node_url)
+
+    # Register account commands
+    register_account_commands(subparsers)
+
+    # Register network commands
+    register_network_commands(subparsers)
+
+    # Add other command groups here if needed (e.g., transaction commands, block commands)
+
+    if len(sys.argv) == 1:
+        # If no command is given, check if address or node_url is set.
+        # If not, prompt the user.
+        # If an address is set, default to showing account balance or some summary.
+        # For now, just print help.
+        cached_address = get_cached_address()
+        cached_node_url = get_cached_node_url()
+        if not cached_address:
+            print("No Ethereum address set. Use 'eth_cli set_address <YOUR_ADDRESS>' to set it.")
+            parser.print_help(sys.stderr)
+            sys.exit(1)
+        if not cached_node_url:
+            print("No Ethereum node URL set. Use 'eth_cli set_node_url <YOUR_NODE_URL>' to set it.")
+            print("You can get a free one from services like Infura (infura.io) or Alchemy (alchemy.com).")
+            parser.print_help(sys.stderr)
+            sys.exit(1)
+        # If both are set, could default to a specific command, e.g., get_balance
+        # For now, if they are set but no command is given, also print help.
+        parser.print_help(sys.stderr)
+        sys.exit(1)
+
+
+    args = parser.parse_args()
+
+    # Execute the function associated with the chosen command
+    # Some commands like set_address don't need node_url or address
+    if hasattr(args, 'func'):
+        if args.command in ["set_address", "set_node_url"]:
+            args.func(args)
+        else:
+            # For other commands, ensure address and node_url are available
+            address = get_cached_address()
+            node_url = get_cached_node_url()
+
+            if not address and not getattr(args, 'address', None):
+                print("Error: Ethereum address not set. Use 'set_address' command or provide address as an argument.")
+                sys.exit(1)
+            if not node_url:
+                print("Error: Ethereum node URL not set. Use 'set_node_url' command.")
+                sys.exit(1)
+
+            # Pass dependencies to the command function
+            args.func(args, node_url, address if not getattr(args, 'address', None) else args.address)
+
+if __name__ == "__main__":
+    main()

--- a/network_commands.py
+++ b/network_commands.py
@@ -1,51 +1,55 @@
-import click
+from web3 import Web3
+from datetime import datetime
 
-@click.group('network')
-def network_group():
-    """Manage and view Ethereum networks."""
-    pass
+def get_web3_instance(node_url):
+    """Initializes and returns a Web3 instance connected to the given node URL."""
+    # This is duplicated from account_commands.py, consider refactoring to a shared utils module later
+    return Web3(Web3.HTTPProvider(node_url))
 
-@network_group.command('list')
-def list_networks():
-    """Show available networks."""
-    click.echo("Listing available networks...")
-    # Placeholder: Implement actual network listing logic
-    click.echo("- mainnet")
-    click.echo("- goerli")
-    click.echo("- sepolia")
+def get_latest_block(args, node_url, default_address=None): # default_address is not used but kept for consistency
+    """Fetches and displays information about the latest mined block."""
+    try:
+        w3 = get_web3_instance(node_url)
+        if not w3.is_connected():
+            print(f"Error: Could not connect to Ethereum node at {node_url}")
+            return
 
-@network_group.command('use')
-@click.argument('network_name', type=str)
-def use_network(network_name):
-    """Switch active network (mainnet, goerli, sepolia, etc.)."""
-    click.echo(f"Switching active network to: {network_name}")
-    # Placeholder: Implement network switching logic
+        latest_block = w3.eth.get_block('latest')
+        print("Latest Block Information:")
+        print(f"  Number: {latest_block.number}")
+        print(f"  Timestamp: {datetime.fromtimestamp(latest_block.timestamp).strftime('%Y-%m-%d %H:%M:%S UTC')}")
+        print(f"  Miner: {latest_block.miner}")
+        print(f"  Gas Used: {latest_block.gasUsed}")
+        print(f"  Gas Limit: {latest_block.gasLimit}")
+        print(f"  Hash: {latest_block.hash.hex()}")
+        print(f"  Parent Hash: {latest_block.parentHash.hex()}")
+        print(f"  Transactions: {len(latest_block.transactions)}")
+    except Exception as e:
+        print(f"Error fetching latest block data: {e}")
 
-@network_group.command('add')
-@click.argument('name', type=str)
-@click.option('--rpc', 'rpc_url', required=True, type=str, help="RPC URL of the custom network.")
-def add_network(name, rpc_url):
-    """Add a custom network."""
-    click.echo(f"Adding custom network '{name}' with RPC URL: {rpc_url}")
-    # Placeholder: Implement custom network addition logic
+def get_gas_price(args, node_url, default_address=None): # default_address is not used but kept for consistency
+    """Fetches and displays the current gas price."""
+    try:
+        w3 = get_web3_instance(node_url)
+        if not w3.is_connected():
+            print(f"Error: Could not connect to Ethereum node at {node_url}")
+            return
 
-@network_group.command('remove')
-@click.argument('name', type=str)
-def remove_network(name):
-    """Remove a network."""
-    click.echo(f"Removing network: {name}")
-    # Placeholder: Implement network removal logic
+        gas_price_wei = w3.eth.gas_price
+        gas_price_gwei = w3.from_wei(gas_price_wei, 'gwei')
+        print(f"Current Gas Price: {gas_price_gwei} Gwei ({gas_price_wei} Wei)")
+    except Exception as e:
+        print(f"Error fetching gas price: {e}")
 
-@network_group.command('info')
-def network_info():
-    """Show current network info (chain ID, gas price, peers)."""
-    click.echo("Displaying current network information...")
-    # Placeholder: Implement logic to fetch and display network info
-    click.echo("Chain ID: 1 (Example Mainnet)")
-    click.echo("Current Gas Price: 50 Gwei")
-    click.echo("Connected Peers: 10")
+def register_network_commands(subparsers):
+    """Registers network-related subcommands to the main parser."""
+    network_parser = subparsers.add_parser("network", help="Commands for Ethereum network information")
+    network_subparsers = network_parser.add_subparsers(title="network_commands", dest="network_command", required=True)
 
-if __name__ == '__main__':
-    # This allows testing the command group independently, if necessary
-    # For example: python network_commands.py list
-    network_group()
+    # Get latest block command
+    latest_block_parser = network_subparsers.add_parser("latest_block", help="Get information about the latest block.")
+    latest_block_parser.set_defaults(func=get_latest_block)
+
+    # Get gas price command
+    gas_price_parser = network_subparsers.add_parser("gas_price", help="Get the current gas price.")
+    gas_price_parser.set_defaults(func=get_gas_price)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+web3
+python-dotenv


### PR DESCRIPTION
This commit introduces a new CLI tool for interacting with the Ethereum blockchain.

Features:
- Cache user's Ethereum address and node URL locally.
- `account` commands:
  - `balance [ADDRESS]`: Get ETH balance.
  - `tx_count [ADDRESS]`: Get transaction count (nonce).
- `network` commands:
  - `latest_block`: Get information about the latest mined block.
  - `gas_price`: Get the current network gas price.

Includes:
- Main script `eth_cli.py` with argparse for command handling.
- `account_commands.py` for account-related functionalities.
- `network_commands.py` for network data functionalities.
- `requirements.txt` with `web3` dependency.
- `README.md` with installation and usage instructions.

Basic error handling for invalid inputs and connection issues is included. The tool prompts users to set their address and node URL if not already cached.